### PR TITLE
fix(setup): stop Linux install from hanging on invisible prompts

### DIFF
--- a/setup.ts
+++ b/setup.ts
@@ -280,17 +280,64 @@ async function installBrewPackages(): Promise<void> {
   }
 }
 
+// Every sudo/installer call below runs with stdio piped, so a password prompt
+// or an installer question is invisible and the run appears to hang forever.
+// Ask for the sudo password once, up front, with the prompt actually visible.
+let sudoKeepAlive: NodeJS.Timeout | null = null;
+
+async function ensureSudo(): Promise<boolean> {
+  if (!IS_LINUX || IS_CI) return true;
+
+  // Already have a valid timestamp? Nothing to do.
+  try {
+    await execa('sudo', ['-n', 'true']);
+    startSudoKeepAlive();
+    return true;
+  } catch {
+    // Needs a password below.
+  }
+
+  log('Some packages need sudo. Enter your password once and the rest runs unattended:', 'info');
+  try {
+    // stdio: 'inherit' is the whole point — the prompt reaches your terminal.
+    await execa('sudo', ['-v'], { stdio: 'inherit' });
+    startSudoKeepAlive();
+    return true;
+  } catch {
+    log('sudo authentication failed; skipping steps that require root', 'warning');
+    return false;
+  }
+}
+
+// Long installs can outlive sudo's 15-minute timestamp; refresh it while we work.
+function startSudoKeepAlive(): void {
+  if (sudoKeepAlive) return;
+  sudoKeepAlive = setInterval(() => {
+    execa('sudo', ['-n', '-v']).catch(() => {});
+  }, 60000);
+  sudoKeepAlive.unref();
+}
+
+function stopSudoKeepAlive(): void {
+  if (sudoKeepAlive) {
+    clearInterval(sudoKeepAlive);
+    sudoKeepAlive = null;
+  }
+}
+
 async function installAptPackages(): Promise<void> {
   if (!await commandExists('apt-get')) {
     log('Error: apt-get not found. Skipping APT package installation.', 'error');
     return;
   }
 
+  if (!await ensureSudo()) return;
+
   log('Installing required packages with APT...', 'info');
 
   const spinner = ora('Updating package lists...').start();
   try {
-    await execa('sudo', ['apt-get', 'update', '-y'], {
+    await execa('sudo', ['-n', 'apt-get', 'update', '-y'], {
       timeout: IS_CI ? 300000 : undefined
     });
     spinner.succeed('Package lists updated');
@@ -308,7 +355,7 @@ async function installAptPackages(): Promise<void> {
     const batch = packages.slice(i, i + BATCH_SIZE);
     const batchSpinner = ora(`Installing batch: ${batch.join(', ')}...`).start();
     try {
-      await execa('sudo', ['apt-get', 'install', '-y', ...batch], {
+      await execa('sudo', ['-n', 'apt-get', 'install', '-y', ...batch], {
         timeout: IS_CI ? 300000 : undefined
       });
       batchSpinner.succeed(`Installed: ${batch.join(', ')}`);
@@ -317,7 +364,7 @@ async function installAptPackages(): Promise<void> {
       for (const pkg of batch) {
         const pkgSpinner = ora(`Installing ${pkg}...`).start();
         try {
-          await execa('sudo', ['apt-get', 'install', '-y', pkg], {
+          await execa('sudo', ['-n', 'apt-get', 'install', '-y', pkg], {
             timeout: IS_CI ? 300000 : undefined
           });
           pkgSpinner.succeed(`Successfully installed ${pkg}`);
@@ -364,6 +411,8 @@ async function createLinuxCompatSymlinks(): Promise<void> {
 
 async function installSpecialPackagesLinux(): Promise<void> {
   log('Installing tools that require special installation methods...', 'info');
+
+  const hasSudo = await ensureSudo();
 
   // sheldon (zsh plugin manager)
   if (!await commandExists('sheldon')) {
@@ -413,7 +462,7 @@ async function installSpecialPackagesLinux(): Promise<void> {
   if (!await commandExists('atuin')) {
     const spinner = ora('Installing atuin...').start();
     try {
-      await execa('bash', ['-c', 'curl --proto "=https" --tlsv1.2 -LsSf https://setup.atuin.sh | sh']);
+      await execa('bash', ['-c', 'curl --proto "=https" --tlsv1.2 -LsSf https://setup.atuin.sh | sh -s -- --non-interactive']);
       spinner.succeed('atuin installed');
     } catch (error) {
       spinner.fail('Failed to install atuin');
@@ -431,7 +480,11 @@ async function installSpecialPackagesLinux(): Promise<void> {
       const { stdout: unameMachine } = await execa('uname', ['-m']);
       const archMap: Record<string, string> = { x86_64: 'x86_64', aarch64: 'arm64', arm64: 'arm64' };
       const arch = archMap[unameMachine] ?? unameMachine;
-      await execa('bash', ['-c', `curl -Lo /tmp/lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/latest/download/lazygit_${version}_Linux_${arch}.tar.gz" && tar xf /tmp/lazygit.tar.gz -C /tmp lazygit && sudo install /tmp/lazygit /usr/local/bin && rm /tmp/lazygit.tar.gz /tmp/lazygit`]);
+      // Install to ~/.local/bin (same place sheldon/bat/fd land) so this needs no root —
+      // a sudo password prompt here would be invisible behind the spinner.
+      const localBin = join(HOME, '.local/bin');
+      mkdirSync(localBin, { recursive: true });
+      await execa('bash', ['-c', `curl -Lo /tmp/lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/latest/download/lazygit_${version}_Linux_${arch}.tar.gz" && tar xf /tmp/lazygit.tar.gz -C /tmp lazygit && install -m755 /tmp/lazygit ${localBin}/lazygit && rm /tmp/lazygit.tar.gz /tmp/lazygit`]);
       spinner.succeed('lazygit installed');
     } catch (error) {
       spinner.fail('Failed to install lazygit');
@@ -445,15 +498,17 @@ async function installSpecialPackagesLinux(): Promise<void> {
   if (!await commandExists('gh')) {
     if (!await commandExists('apt-get')) {
       log('apt-get not found, skipping GitHub CLI installation', 'warning');
+    } else if (!hasSudo) {
+      log('No sudo access, skipping GitHub CLI installation', 'warning');
     } else {
       const spinner = ora('Installing GitHub CLI...').start();
       try {
         await execa('bash', ['-c', [
-          'curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg',
-          'sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg',
-          'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null',
-          'sudo apt-get update -y',
-          'sudo apt-get install -y gh'
+          'curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo -n dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg',
+          'sudo -n chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg',
+          'echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo -n tee /etc/apt/sources.list.d/github-cli.list > /dev/null',
+          'sudo -n apt-get update -y',
+          'sudo -n apt-get install -y gh'
         ].join(' && ')]);
         spinner.succeed('GitHub CLI installed');
       } catch (error) {
@@ -843,6 +898,8 @@ async function main(): Promise<void> {
   } catch (error) {
     console.error(chalk.red('Setup failed:'), error);
     process.exit(1);
+  } finally {
+    stopSudoKeepAlive();
   }
 }
 


### PR DESCRIPTION
## The failure

`npm run setup` on Linux hangs forever, with no output beyond a spinner reading `Installing atuin...`. Ctrl-C doesn't help.

`setup.ts` shells out with `execa`, which defaults to `stdio: 'pipe'`. Several of those subprocesses ask questions on the terminal — and because stdout is piped, **the question is never displayed**. The subprocess sits waiting for an answer to a prompt the user cannot see, and the setup appears to have frozen.

Three distinct instances of the same class of bug:

1. **The atuin installer.** `curl https://setup.atuin.sh | sh` probes `/dev/tty`, decides it is interactive, and blocks on `read -r import_answer </dev/tty` asking *"Would you like to import your existing shell history into Atuin? [Y/n]"*. Invisible → indefinite hang.
2. **`sudo` in the lazygit and `gh` steps.** The password prompt is invisible for exactly the same reason.
3. **The two compounding each other.** A long stall (e.g. the atuin hang) outlives sudo's 15-minute timestamp, so a `sudo` that *would* have been cached silently starts prompting mid-run — turning a one-off failure into a reliably reproducible one.

### Reproduction

Reproduced on Linux Mint (kernel 6.14) via `npm run setup`. As an aggravating factor, the terminal was left in raw mode (`-isig -icanon -echo -icrnl`) by an earlier inquirer prompt, so `Ctrl-C` could not even interrupt the hung run. That part is a symptom of how the terminal is left on abnormal exit, not something addressed here.

## The changes

**Ask for sudo once, visibly, up front.** New `ensureSudo()` helper runs `sudo -v` with `stdio: 'inherit'` so the password prompt actually reaches the terminal. It first tries `sudo -n true` and skips the prompt entirely if a valid timestamp already exists. Returns `false` on auth failure rather than throwing, so callers can degrade gracefully.

**Keep the timestamp alive.** `startSudoKeepAlive()` refreshes it with `sudo -n -v` on a 60s interval; the timer is `unref()`'d so it never holds the process open, and `main()` now has a `finally { stopSudoKeepAlive(); }`.

**Every `sudo` invocation is now `sudo -n`.** This is the belt-and-braces half of the fix: if the timestamp is somehow gone, sudo exits with an error instead of blocking on a prompt nobody can see. Covers the three `apt-get` calls in `installAptPackages()` and all five sudo commands in the `gh` install chain.

**Call sites.** `installAptPackages()` returns early if `ensureSudo()` fails; `installSpecialPackagesLinux()` captures `hasSudo` at the top and the `gh` step now has an `else if (!hasSudo)` branch logging *"No sudo access, skipping GitHub CLI installation"*.

**atuin runs non-interactively.** The upstream script accepts `--non-interactive`, which skips both the history-import and the sync-signup questions:

```ts
curl --proto "=https" --tlsv1.2 -LsSf https://setup.atuin.sh | sh -s -- --non-interactive
```

**lazygit no longer needs root at all.** It was doing `sudo install /tmp/lazygit /usr/local/bin`. It now installs to `~/.local/bin` with `install -m755` — no sudo, no prompt, nothing to hang on.

## ⚠️ Behavioural change to weigh

**lazygit moves from `/usr/local/bin` to `~/.local/bin`.** That's the same directory `sheldon`, `bat` and `fd` already use in this repo, and it's already on `PATH` via `.zprofile` — so for a fresh install this is invisible. Two things to note:

- On a machine that already has lazygit in `/usr/local/bin`, this step is skipped entirely (the `commandExists('lazygit')` guard), so nothing moves. The old copy stays where it is, and updates to it are now manual.
- The install becomes per-user rather than system-wide. If you want lazygit available to other users on the box, that's now a manual `sudo install`.

Dropping the sudo dependency is what makes this step unable to hang, so the trade seemed worth making — happy to revert to `/usr/local/bin` (now safe, since `ensureSudo()` runs first) if you'd rather keep it system-wide.

## Verification

| Check | Result |
|---|---|
| `npm run typecheck` | exit 0 |
| `npm test` | 19/19 pass |
| `CI=true npm run ci:setup` | completes, exit 0 |

`ensureSudo()` short-circuits to `true` under `IS_CI`, so **CI behaviour is unchanged by design** — the CI workflow runs as root and never sees the prompt path.

Two caveats about what the sandbox could and could not verify: its egress proxy blocks `setup.atuin.sh`, `starship.rs`, `rossmacarthur.github.io` and `api.github.com`, so the atuin `--non-interactive` flag could not be exercised against the live upstream script, and the lazygit download 404s there (the version lookup returns empty). The new rootless `tar` + `install -m755 … ~/.local/bin/lazygit` sequence was verified directly against a stub tarball: it produces a `755` executable in the right place with no root. The blocked hosts fail identically on `main`.

`package-lock.json` was deliberately not committed — this repo uses `pnpm-lock.yaml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012FpqbEq8Zdv4xTrnbGhfqQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux setup by prompting for administrative access before installing system packages.
  * Added clearer handling when administrative access is unavailable, allowing unsupported installations to be skipped safely.
  * Improved noninteractive installation behavior for command-line tools.
  * Ensured administrative authentication is cleaned up when setup completes or exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->