### PR TITLE
feat(linux): add macOS-style MX keyboard shortcuts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ ansible-playbook setup.yml -K                     # Re-run on Linux (apt/usermod
 ansible-playbook setup.yml                        # Re-run on macOS
 ansible-playbook setup.yml --skip-tags packages   # Configs only
 ansible-playbook setup.yml -K --skip-tags ollama  # Skip the 1.4 GB ollama build
-ansible-playbook setup.yml -K --tags desktop      # Linux desktop (Ulauncher, Ghostty, Bitwarden, draw.io, Cinnamon, xbindkeys); never runs unless asked
+ansible-playbook setup.yml -K --tags desktop      # Linux desktop (apps, Cinnamon, xbindkeys, xremap); never runs unless asked
 ansible-playbook setup.yml --check --diff         # Dry run (already set-up machine; -K on Linux)
 ansible-playbook setup.yml --syntax-check
 ansible-lint                                      # With ansible-core: ansible-galaxy collection install -r requirements.yml first
@@ -33,15 +33,15 @@ Verify = run the playbook again and expect `changed=0`.
 - `vars/Darwin.yml`, `vars/Debian.yml` — brew prefix, fonts dir, the flattened formula list. Debian
   also holds the apt package list and the formulae brew must not install on Linux.
 - `tasks/symlinks.yml` — `stat` → move anything in the way to `~/.dotfiles_backup/<timestamp>/` → `file state=link`.
-  Parametrised on `links`; imported from `setup.yml` and again from `tasks/desktop.yml` for the xbindkeys files.
+  Parametrised on `links`; imported from `setup.yml` and from `tasks/desktop.yml` for xbindkeys and xremap.
 - `tasks/debian.yml` — apt, zsh as login shell, Homebrew on Linux (the prefix is pre-created user-owned so the
   installer never calls sudo), ollama upstream build + systemd user unit (tag `ollama`).
 - `tasks/desktop.yml` — Ulauncher (PPA), Ghostty (apt or community .deb), Bitwarden and draw.io (upstream
-  .deb), Flameshot/xbindkeys/rofi/wmctrl, Cinnamon hot corners and custom hotkeys via `gsettings`, xbindkeys
-  restart. Tagged `[desktop, never]`.
+  .deb), Flameshot/xbindkeys/rofi/wmctrl, Cinnamon hot corners and custom hotkeys via `gsettings`, and pinned
+  app-aware xremap with explicit input/uinput provisioning. Tagged `[desktop, never]`.
 - `brew_packages.yml` — `formulae:` grouped by category plus `casks:`; used on both OSes.
 - `.config/` (nvim, ghostty, atuin, sheldon, yazi, starship.toml), `zsh/`, `tmux/`, `xbindkeys/`, `claude/`,
-  `codex/`, `fonts/` — the linked/copied content.
+  `codex/`, `xremap/`, `fonts/` — the linked/copied content.
 
 ## Key Implementation Details
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,10 @@ On Cinnamon/X11, the desktop tag installs an app-aware, MX Mechanical-only
 xremap configuration for macOS-style Command shortcuts. It adds the account to
 the `input` group, which grants input-device access equivalent to keylogging;
 sign out and back in after the first run. Stop `xremap` to disable the remapping
-immediately. Other desktop/session types are left unchanged.
+immediately. An exact-name supervisor keeps the remapper scoped to that keyboard
+across sleep, reconnects, and event-number changes; unknown application classes
+use terminal-safe mappings rather than risk sending shell control keys. Other
+desktop/session types are left unchanged.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -84,10 +84,11 @@ ansible-playbook setup.yml       # macOS
 
 Existing files in the way of a symlink are moved to `~/.dotfiles_backup/<timestamp>/` first. There is no interactive prompting — the playbook always backs up, then links.
 
-The desktop tag installs an app-aware, MX Mechanical-only xremap configuration
-for macOS-style Command shortcuts. It adds the account to the `input` group,
-which grants input-device access equivalent to keylogging; sign out and back in
-after the first run. Stop `xremap` to disable the remapping immediately.
+On Cinnamon/X11, the desktop tag installs an app-aware, MX Mechanical-only
+xremap configuration for macOS-style Command shortcuts. It adds the account to
+the `input` group, which grants input-device access equivalent to keylogging;
+sign out and back in after the first run. Stop `xremap` to disable the remapping
+immediately. Other desktop/session types are left unchanged.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -76,13 +76,18 @@ ansible-playbook setup.yml       # macOS
 | Configs only, no packages | `ansible-playbook setup.yml --skip-tags packages` |
 | Just the symlinks / fonts / tmux / secrets | `ansible-playbook setup.yml --tags symlinks` (or `fonts`, `tmux`, `secrets`) |
 | Skip the 1.4 GB ollama build (Linux) | `ansible-playbook setup.yml -K --skip-tags ollama` |
-| Linux desktop: Ulauncher, Ghostty, Bitwarden, draw.io, Flameshot, Cinnamon hot corners/hotkeys, xbindkeys | `ansible-playbook setup.yml -K --tags desktop` (never runs unless asked; needs a graphical session) |
+| Linux desktop: Ulauncher, Ghostty, Bitwarden, draw.io, Flameshot, Cinnamon hot corners/hotkeys, xbindkeys, xremap | `ansible-playbook setup.yml -K --tags desktop` (never runs unless asked; needs a graphical session) |
 | Dry run (on an already set-up machine; `-K` on Linux) | `ansible-playbook setup.yml --check --diff` |
 | Verify | Run it again and expect `changed=0` |
 
 `./bootstrap.sh` passes extra arguments through, so `./bootstrap.sh --tags symlinks` works too.
 
 Existing files in the way of a symlink are moved to `~/.dotfiles_backup/<timestamp>/` first. There is no interactive prompting — the playbook always backs up, then links.
+
+The desktop tag installs an app-aware, MX Mechanical-only xremap configuration
+for macOS-style Command shortcuts. It adds the account to the `input` group,
+which grants input-device access equivalent to keylogging; sign out and back in
+after the first run. Stop `xremap` to disable the remapping immediately.
 
 ## Configuration
 
@@ -113,6 +118,7 @@ Existing files in the way of a symlink are moved to `~/.dotfiles_backup/<timesta
 ├── zsh/                  # .zprofile, .zshrc, .zshrc.core
 ├── tmux/                 # .tmux.conf
 ├── xbindkeys/            # Linux mouse-button / tiling bindings
+├── xremap/               # MX keyboard macOS-style Command shortcuts
 └── fonts/                # Nerd Font collections
 ```
 

--- a/setup.yml
+++ b/setup.yml
@@ -198,3 +198,19 @@
       ansible.builtin.import_tasks: tasks/desktop.yml
       when: ansible_os_family == 'Debian'
       tags: [desktop, never]
+
+  handlers:
+    - name: Reload udev rules for uinput
+      ansible.builtin.command: udevadm control --reload-rules
+      changed_when: true
+      become: true
+
+    - name: Load uinput module
+      ansible.builtin.command: modprobe uinput
+      changed_when: true
+      become: true
+
+    - name: Apply uinput permissions
+      ansible.builtin.command: udevadm trigger --action=change --name-match=uinput
+      changed_when: true
+      become: true

--- a/setup.yml
+++ b/setup.yml
@@ -198,19 +198,3 @@
       ansible.builtin.import_tasks: tasks/desktop.yml
       when: ansible_os_family == 'Debian'
       tags: [desktop, never]
-
-  handlers:
-    - name: Reload udev rules for uinput
-      ansible.builtin.command: udevadm control --reload-rules
-      changed_when: true
-      become: true
-
-    - name: Load uinput module
-      ansible.builtin.command: modprobe uinput
-      changed_when: true
-      become: true
-
-    - name: Apply uinput permissions
-      ansible.builtin.command: udevadm trigger --action=change --name-match=uinput
-      changed_when: true
-      become: true

--- a/tasks/desktop.yml
+++ b/tasks/desktop.yml
@@ -124,6 +124,9 @@
 # process connecting to X11, but requires the input group and uinput access. The
 # new group is picked up at the next login, when the autostart entry first runs.
 - name: Xremap
+  when:
+    - "'cinnamon' in (ansible_env.XDG_CURRENT_DESKTOP | lower)"
+    - (ansible_env.XDG_SESSION_TYPE | default('')) == 'x11'
   vars:
     xremap_version: 0.15.11
     xremap_arch: "{{ {'x86_64': 'x86_64', 'aarch64': 'aarch64', 'arm64': 'aarch64'}.get(ansible_architecture, ansible_architecture) }}"
@@ -202,7 +205,9 @@
 
     - name: Uinput module at boot
       ansible.builtin.copy:
-        dest: /etc/modules-load.d/uinput.conf
+        dest: /etc/modules-load.d/xremap-uinput.conf
+        owner: root
+        group: root
         mode: "0644"
         content: "uinput\n"
       become: true
@@ -213,7 +218,9 @@
 
     - name: Uinput access for input group
       ansible.builtin.copy:
-        dest: /etc/udev/rules.d/99-input.rules
+        dest: /etc/udev/rules.d/99-xremap-uinput.rules
+        owner: root
+        group: root
         mode: "0644"
         content: |
           KERNEL=="uinput", GROUP="input", MODE:="0660", OPTIONS+="static_node=uinput"
@@ -238,7 +245,7 @@
           Type=Application
           Name=xremap
           TryExec={{ home }}/.local/bin/xremap
-          Exec={{ home }}/.local/bin/xremap --device "MX MCHNCL Keyboard" --watch=config,device {{ home }}/.config/xremap/config.yml
+          Exec={{ home }}/.config/xremap/start
           X-GNOME-Autostart-enabled=true
           NoDisplay=true
 

--- a/tasks/desktop.yml
+++ b/tasks/desktop.yml
@@ -140,7 +140,9 @@
   block:
     - name: Xremap architecture supported
       ansible.builtin.assert:
-        that: xremap_arch in xremap_checksums
+        that:
+          - xremap_arch in xremap_checksums
+          - xremap_arch in xremap_binary_checksums
         fail_msg: "No pinned xremap binary for architecture {{ ansible_architecture }}"
         quiet: true
 
@@ -149,7 +151,6 @@
         path: "{{ home }}/.local/bin/xremap"
         checksum_algorithm: sha256
       register: xremap_binary
-      changed_when: false
       check_mode: false
 
     - name: Xremap directories # noqa: risky-file-permissions
@@ -167,8 +168,16 @@
         checksum: "sha256:{{ xremap_checksums[xremap_arch] }}"
         mode: "0644"
       when: >-
-        not xremap_binary.stat.exists
-        or xremap_binary.stat.checksum != xremap_binary_checksums[xremap_arch]
+        not (xremap_binary.stat.isreg | default(false))
+        or (xremap_binary.stat.checksum | default('')) != xremap_binary_checksums[xremap_arch]
+
+    - name: Invalid xremap binary path absent
+      ansible.builtin.file:
+        path: "{{ home }}/.local/bin/xremap"
+        state: absent
+      when:
+        - xremap_binary.stat.exists
+        - not (xremap_binary.stat.isreg | default(false))
 
     - name: Xremap binary
       ansible.builtin.unarchive:
@@ -176,17 +185,17 @@
         dest: "{{ home }}/.local/bin"
         remote_src: true
       when:
-        - not xremap_binary.stat.exists or xremap_binary.stat.checksum != xremap_binary_checksums[xremap_arch]
+        - not (xremap_binary.stat.isreg | default(false)) or (xremap_binary.stat.checksum | default('')) != xremap_binary_checksums[xremap_arch]
         - not ansible_check_mode
 
+    # SHA-256 does not cover mode bits. Enforce executable-mode drift on existing
+    # binaries, but skip a nonexistent path during fresh-machine check mode.
     - name: Xremap binary executable
       ansible.builtin.file:
         path: "{{ home }}/.local/bin/xremap"
         mode: "0755"
-      when: >-
-        not ansible_check_mode
-        or (xremap_binary.stat.exists
-            and xremap_binary.stat.checksum == xremap_binary_checksums[xremap_arch])
+      when:
+        - not ansible_check_mode or (xremap_binary.stat.isreg | default(false))
 
     # Reading event devices is equivalent to keylogger access. Keep this explicit
     # rather than hiding it in a privileged service or running xremap as root.
@@ -214,8 +223,9 @@
 
     # Converge live state too: a no-change run must repair an unloaded module.
     - name: Uinput module loaded
-      ansible.builtin.command: modprobe uinput
-      changed_when: false
+      community.general.modprobe:
+        name: uinput
+        state: present
       become: true
 
     - name: Uinput access for input group
@@ -258,6 +268,70 @@
           Exec={{ home }}/.config/xremap/start
           X-GNOME-Autostart-enabled=true
           NoDisplay=true
+
+    - name: Xremap supervisor running
+      ansible.builtin.shell: |
+        pidfile="{{ home }}/.cache/xremap-supervisor.pid"
+        [ -r "$pidfile" ] && kill -0 "$(cat "$pidfile")" 2>/dev/null
+        cmdline=$(tr '\0' ' ' < "/proc/$(cat "$pidfile")/cmdline")
+        case "$cmdline" in *"{{ home }}/.config/xremap/start"*) exit 0;; *) exit 1;; esac
+      register: xremap_pgrep
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: Effective input group membership
+      ansible.builtin.command: id -nG
+      register: effective_groups
+      changed_when: false
+      check_mode: false
+
+    - name: Stop legacy directly launched xremap
+      ansible.builtin.shell: |
+        binary="{{ home }}/.local/bin/xremap"
+        config="{{ home }}/.config/xremap/config.yml"
+        changed=false
+        for pid in $(pgrep -u "$(id -u)" -x xremap || true); do
+          cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline")
+          case "$cmdline" in
+            "$binary"*"$config"*)
+              kill "$pid"
+              changed=true
+              for _ in 1 2 3 4 5; do
+                kill -0 "$pid" 2>/dev/null || break
+                sleep 0.2
+              done
+              kill -0 "$pid" 2>/dev/null && exit 1
+              ;;
+          esac
+        done
+        $changed && echo changed
+        exit 0
+      register: legacy_xremap
+      changed_when: "'changed' in legacy_xremap.stdout"
+      when: xremap_pgrep.rc != 0
+
+    - name: Start xremap
+      ansible.builtin.shell: >-
+        setsid "{{ home }}/.config/xremap/start"
+        >"{{ home }}/.cache/xremap.log" 2>&1 &
+      changed_when: true
+      when:
+        - xremap_pgrep.rc != 0
+        - "'input' in effective_groups.stdout.split()"
+
+    - name: Xremap supervisor alive
+      ansible.builtin.shell: |
+        pidfile="{{ home }}/.cache/xremap-supervisor.pid"
+        [ -r "$pidfile" ] && kill -0 "$(cat "$pidfile")" 2>/dev/null
+        cmdline=$(tr '\0' ' ' < "/proc/$(cat "$pidfile")/cmdline")
+        case "$cmdline" in *"{{ home }}/.config/xremap/start"*) exit 0;; *) exit 1;; esac
+      register: xremap_alive
+      until: xremap_alive.rc == 0
+      retries: 5
+      delay: 1
+      changed_when: false
+      when: "'input' in effective_groups.stdout.split()"
 
 # The hotkey is useless without a live daemon; neither the autostart entry nor
 # starting it needs root.
@@ -354,6 +428,7 @@
         label: "Super+{{ item.letter | upper }} -> Ctrl+Super+{{ item.letter | upper }}"
       register: cinnamon_super_shortcuts
       changed_when: "'changed' in cinnamon_super_shortcuts.stdout"
+      when: (ansible_env.XDG_SESSION_TYPE | default('')) == 'x11'
 
     # Cinnamon keeps custom shortcuts as custom0/custom1/... under a relocatable
     # schema plus a list naming the live ones. Reuse the slot already holding

--- a/tasks/desktop.yml
+++ b/tasks/desktop.yml
@@ -1,6 +1,6 @@
 ---
 # Linux desktop: Ulauncher, Ghostty, Flameshot, Bitwarden, draw.io, Cinnamon
-# settings, xbindkeys.
+# settings, xbindkeys, xremap.
 # Only reached via --tags desktop (see setup.yml). Failing loudly beats the
 # alternative — every task silently skipping on an SSH run that asked for
 # desktop by name.
@@ -28,7 +28,7 @@
 # to xprop/xwininfo, which cinnamon-core does not guarantee.
 - name: Desktop packages
   ansible.builtin.apt:
-    name: [ulauncher, flameshot, xbindkeys, rofi, wmctrl, x11-utils]
+    name: [ulauncher, flameshot, xbindkeys, rofi, unzip, wmctrl, x11-utils]
   become: true
 
 # Ghostty reached the Ubuntu archive in 26.04. Older bases (Mint 22 sits on
@@ -116,6 +116,132 @@
     path: "{{ home }}/.config/autostart"
     state: directory
 
+# Super is the MX Mechanical key in the macOS Command position. A whole-key
+# swap would turn terminal copy into SIGINT and would destroy Cinnamon's Super
+# shortcuts, so xremap translates only an exact allowlist and can special-case
+# terminal windows. Limit capture to the MX keyboard: the laptop/other keyboards
+# retain normal Linux semantics. Running as the desktop user avoids a root-owned
+# process connecting to X11, but requires the input group and uinput access. The
+# new group is picked up at the next login, when the autostart entry first runs.
+- name: Xremap
+  vars:
+    xremap_version: 0.15.11
+    xremap_arch: "{{ {'x86_64': 'x86_64', 'aarch64': 'aarch64', 'arm64': 'aarch64'}.get(ansible_architecture, ansible_architecture) }}"
+    xremap_archive: "{{ home }}/.cache/xremap-{{ xremap_version }}-{{ xremap_arch }}-x11.zip"
+    xremap_checksums:
+      x86_64: 2e83a3befde38747087cc740492a4af73feb3a5a3705fbdc71a48ec916601723
+      aarch64: 4593ec9ea7ca6ec9472254bbc6a7551f77ba8daec01986c6b3a4d7534d9da7f1
+    xremap_binary_checksums:
+      x86_64: ddbf3a43623d10b3bf6f4737fc3ebb8c49b9882b5b4920eba084f0aacc8a025c
+      aarch64: bf580a96c73efb38dfc79b947dfc514c22e7bf62c403b7b29c3baa010d3fe8ff
+  block:
+    - name: Xremap architecture supported
+      ansible.builtin.assert:
+        that: xremap_arch in xremap_checksums
+        fail_msg: "No pinned xremap binary for architecture {{ ansible_architecture }}"
+        quiet: true
+
+    - name: Xremap installed binary
+      ansible.builtin.stat:
+        path: "{{ home }}/.local/bin/xremap"
+        checksum_algorithm: sha256
+      register: xremap_binary
+      changed_when: false
+      check_mode: false
+
+    - name: Xremap directories # noqa: risky-file-permissions
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+      loop:
+        - "{{ home }}/.cache"
+        - "{{ home }}/.local/bin"
+
+    - name: Xremap archive
+      ansible.builtin.get_url:
+        url: "https://github.com/xremap/xremap/releases/download/v{{ xremap_version }}/xremap-linux-{{ xremap_arch }}-x11.zip"
+        dest: "{{ xremap_archive }}"
+        checksum: "sha256:{{ xremap_checksums[xremap_arch] }}"
+        mode: "0644"
+      when: >-
+        not xremap_binary.stat.exists
+        or xremap_binary.stat.checksum != xremap_binary_checksums[xremap_arch]
+
+    - name: Xremap binary
+      ansible.builtin.unarchive:
+        src: "{{ xremap_archive }}"
+        dest: "{{ home }}/.local/bin"
+        remote_src: true
+      when:
+        - not xremap_binary.stat.exists or xremap_binary.stat.checksum != xremap_binary_checksums[xremap_arch]
+        - not ansible_check_mode
+
+    - name: Xremap binary executable
+      ansible.builtin.file:
+        path: "{{ home }}/.local/bin/xremap"
+        mode: "0755"
+      when: >-
+        not ansible_check_mode
+        or (xremap_binary.stat.exists
+            and xremap_binary.stat.checksum == xremap_binary_checksums[xremap_arch])
+
+    # Reading event devices is equivalent to keylogger access. Keep this explicit
+    # rather than hiding it in a privileged service or running xremap as root.
+    - name: Input group
+      ansible.builtin.group:
+        name: input
+        system: true
+      become: true
+
+    - name: Input group membership
+      ansible.builtin.user:
+        name: "{{ ansible_user_id }}"
+        groups: input
+        append: true
+      become: true
+
+    - name: Uinput module at boot
+      ansible.builtin.copy:
+        dest: /etc/modules-load.d/uinput.conf
+        mode: "0644"
+        content: "uinput\n"
+      become: true
+      notify:
+        - Reload udev rules for uinput
+        - Load uinput module
+        - Apply uinput permissions
+
+    - name: Uinput access for input group
+      ansible.builtin.copy:
+        dest: /etc/udev/rules.d/99-input.rules
+        mode: "0644"
+        content: |
+          KERNEL=="uinput", GROUP="input", MODE:="0660", OPTIONS+="static_node=uinput"
+      become: true
+      notify:
+        - Reload udev rules for uinput
+        - Load uinput module
+        - Apply uinput permissions
+
+    - name: Xremap config link
+      ansible.builtin.import_tasks: symlinks.yml
+      vars:
+        links:
+          - { src: xremap, dest: .config/xremap }
+
+    - name: Xremap autostart
+      ansible.builtin.copy:
+        dest: "{{ home }}/.config/autostart/xremap.desktop"
+        mode: "0644"
+        content: |
+          [Desktop Entry]
+          Type=Application
+          Name=xremap
+          TryExec={{ home }}/.local/bin/xremap
+          Exec={{ home }}/.local/bin/xremap --device "MX MCHNCL Keyboard" --watch=config,device {{ home }}/.config/xremap/config.yml
+          X-GNOME-Autostart-enabled=true
+          NoDisplay=true
+
 # The hotkey is useless without a live daemon; neither the autostart entry nor
 # starting it needs root.
 - name: Ulauncher autostart
@@ -187,6 +313,30 @@
         executable: /bin/bash
       register: window_menu
       changed_when: "'changed' in window_menu.stdout"
+
+    # These four defaults overlap common Command shortcuts (location, open,
+    # print and save). Keep the Cinnamon actions available one chord higher;
+    # xremap uses exact matching, so Ctrl+Super passes through untouched.
+    - name: Move conflicting Cinnamon Super shortcuts to Ctrl+Super
+      ansible.builtin.shell: |
+        set -e -o pipefail
+        cur=$(gsettings get {{ item.schema }} {{ item.key }})
+        if [[ $cur == *"'<Super>{{ item.letter }}'"* ]]; then
+          new=$(printf '%s' "$cur" | sed "s/'<Super>{{ item.letter }}'/'<Control><Super>{{ item.letter }}'/")
+          gsettings set {{ item.schema }} {{ item.key }} "$new"
+          echo changed
+        fi
+      args:
+        executable: /bin/bash
+      loop:
+        - { schema: org.cinnamon.desktop.keybindings, key: looking-glass-keybinding, letter: l }
+        - { schema: org.cinnamon.desktop.keybindings, key: show-desklets, letter: s }
+        - { schema: org.cinnamon.desktop.keybindings.media-keys, key: video-rotation-lock, letter: o }
+        - { schema: org.cinnamon.desktop.keybindings.wm, key: switch-monitor, letter: p }
+      loop_control:
+        label: "Super+{{ item.letter | upper }} -> Ctrl+Super+{{ item.letter | upper }}"
+      register: cinnamon_super_shortcuts
+      changed_when: "'changed' in cinnamon_super_shortcuts.stdout"
 
     # Cinnamon keeps custom shortcuts as custom0/custom1/... under a relocatable
     # schema plus a list naming the live ones. Reuse the slot already holding

--- a/tasks/desktop.yml
+++ b/tasks/desktop.yml
@@ -374,6 +374,36 @@
 - name: Cinnamon settings
   when: "'cinnamon' in (ansible_env.XDG_CURRENT_DESKTOP | lower)"
   block:
+    # Keep US as the primary layout and add Bulgarian's traditional phonetic
+    # variant. Cinnamon handles layout switching itself; the matching WM
+    # keybindings preserve the hardware keyboard key and add
+    # Ctrl+Super+Space / Ctrl+Shift+Super+Space switching explicitly.
+    - name: Keyboard layouts and input switching
+      ansible.builtin.shell: |
+        set -e
+        current=$(gsettings get {{ item.schema }} {{ item.key }})
+        desired="{{ item.value }}"
+        if [ "$current" != "$desired" ]; then
+          gsettings set {{ item.schema }} {{ item.key }} "$desired"
+          echo changed
+        fi
+      args:
+        executable: /bin/bash
+      loop:
+        - schema: org.cinnamon.desktop.input-sources
+          key: sources
+          value: "[('xkb', 'us'), ('xkb', 'bg+phonetic')]"
+        - schema: org.cinnamon.desktop.keybindings.wm
+          key: switch-input-source
+          value: "['<Control><Super>space', 'XF86Keyboard']"
+        - schema: org.cinnamon.desktop.keybindings.wm
+          key: switch-input-source-backward
+          value: "['<Control><Shift><Super>space', '<Shift>XF86Keyboard']"
+      loop_control:
+        label: "{{ item.schema }} {{ item.key }}"
+      register: keyboard_input
+      changed_when: "'changed' in keyboard_input.stdout"
+
     - name: Hot corners (current)
       ansible.builtin.command: gsettings get org.cinnamon hotcorner-layout
       register: hotcorners

--- a/tasks/desktop.yml
+++ b/tasks/desktop.yml
@@ -211,10 +211,12 @@
         mode: "0644"
         content: "uinput\n"
       become: true
-      notify:
-        - Reload udev rules for uinput
-        - Load uinput module
-        - Apply uinput permissions
+
+    # Converge live state too: a no-change run must repair an unloaded module.
+    - name: Uinput module loaded
+      ansible.builtin.command: modprobe uinput
+      changed_when: false
+      become: true
 
     - name: Uinput access for input group
       ansible.builtin.copy:
@@ -225,10 +227,18 @@
         content: |
           KERNEL=="uinput", GROUP="input", MODE:="0660", OPTIONS+="static_node=uinput"
       become: true
-      notify:
-        - Reload udev rules for uinput
-        - Load uinput module
-        - Apply uinput permissions
+
+    # Reload and trigger on every normal run so unchanged files can still repair
+    # daemon/runtime drift. Both commands are idempotent from Ansible's view.
+    - name: Udev rules loaded
+      ansible.builtin.command: udevadm control --reload-rules
+      changed_when: false
+      become: true
+
+    - name: Uinput permissions applied
+      ansible.builtin.command: udevadm trigger --action=change --name-match=uinput
+      changed_when: false
+      become: true
 
     - name: Xremap config link
       ansible.builtin.import_tasks: symlinks.yml

--- a/xbindkeys/.xbindkeysrc
+++ b/xbindkeys/.xbindkeysrc
@@ -16,7 +16,8 @@
 
 # Rectangle-style window tiling on Ctrl+Super. Rectangle's own Ctrl+Alt is taken
 # here: the arrows switch workspace and Ctrl+Alt+T opens a terminal. Ctrl+Super
-# is unbound across the whole gsettings tree, so nothing has to be surrendered.
+# avoids Cinnamon's native Ctrl+Alt chords. The setup reserves Ctrl+Super+L/S/O/P
+# for migrated Cinnamon actions; the tiling bindings below use different keys.
 #
 # Each quoted argument is one "X Y W H" position; repeating the binding steps to
 # the next one and wraps, the way Rectangle cycles. The keys that lead a group

--- a/xremap/config.yml
+++ b/xremap/config.yml
@@ -24,6 +24,8 @@ keymap:
       Super-F: Ctrl-Shift-F
       Super-N: Ctrl-Shift-N
       Super-T: Ctrl-Shift-T
+      Super-W: Ctrl-Shift-W
+      Super-Q: Ctrl-Shift-Q
       Super-K: Ctrl-L
       Super-Equal: Ctrl-Equal
       Super-Minus: Ctrl-Minus
@@ -51,11 +53,13 @@ keymap:
       Super-N: Ctrl-N
       Super-O: Ctrl-O
       Super-P: Ctrl-P
+      Super-Q: Ctrl-Q
       Super-R: Ctrl-R
       Super-S: Ctrl-S
       Super-T: Ctrl-T
       Super-U: Ctrl-U
       Super-V: Ctrl-V
+      Super-W: Ctrl-W
       Super-X: Ctrl-X
       Super-Z: Ctrl-Z
       Super-Shift-Z: Ctrl-Shift-Z

--- a/xremap/config.yml
+++ b/xremap/config.yml
@@ -1,0 +1,64 @@
+---
+# macOS-style Command shortcuts for the MX Mechanical keyboard.
+#
+# The key in the Command position reports as Super on Linux. Exact matches are
+# deliberate: Cinnamon's Super+arrows, Super+Tab, Super+Space and xbindkeys'
+# Ctrl+Super tiling bindings pass through unchanged.
+keymap:
+  # Terminal emulators need their own clipboard/window actions. Sending Ctrl+C
+  # here would interrupt the foreground process instead of copying text.
+  - name: macOS shortcuts in terminals
+    application:
+      only:
+        - /(?i)ghostty/
+        - /(?i)gnome-terminal/
+        - /(?i)alacritty/
+        - /(?i)kitty/
+        - /(?i)konsole/
+        - /(?i)wezterm/
+    exact_match: true
+    remap:
+      Super-C: Ctrl-Shift-C
+      Super-V: Ctrl-Shift-V
+      Super-A: Ctrl-Shift-A
+      Super-F: Ctrl-Shift-F
+      Super-N: Ctrl-Shift-N
+      Super-T: Ctrl-Shift-T
+      Super-K: Ctrl-L
+      Super-Equal: Ctrl-Equal
+      Super-Minus: Ctrl-Minus
+      Super-0: Ctrl-0
+
+  # Normal Linux applications conventionally expose these actions through
+  # Ctrl. Terminal windows are excluded so shell control keys remain intact.
+  - name: macOS shortcuts in desktop applications
+    application:
+      not:
+        - /(?i)ghostty/
+        - /(?i)gnome-terminal/
+        - /(?i)alacritty/
+        - /(?i)kitty/
+        - /(?i)konsole/
+        - /(?i)wezterm/
+    exact_match: true
+    remap:
+      Super-A: Ctrl-A
+      Super-B: Ctrl-B
+      Super-C: Ctrl-C
+      Super-F: Ctrl-F
+      Super-I: Ctrl-I
+      Super-L: Ctrl-L
+      Super-N: Ctrl-N
+      Super-O: Ctrl-O
+      Super-P: Ctrl-P
+      Super-R: Ctrl-R
+      Super-S: Ctrl-S
+      Super-T: Ctrl-T
+      Super-U: Ctrl-U
+      Super-V: Ctrl-V
+      Super-X: Ctrl-X
+      Super-Z: Ctrl-Z
+      Super-Shift-Z: Ctrl-Shift-Z
+      Super-Equal: Ctrl-Equal
+      Super-Minus: Ctrl-Minus
+      Super-0: Ctrl-0

--- a/xremap/config.yml
+++ b/xremap/config.yml
@@ -4,44 +4,60 @@
 # The key in the Command position reports as Super on Linux. Exact matches are
 # deliberate: Cinnamon's Super+arrows, Super+Tab, Super+Space and xbindkeys'
 # Ctrl+Super tiling bindings pass through unchanged.
+shared:
+  # IDE terminals have the same WM_CLASS as their editor. Treating the whole IDE
+  # as a terminal is conservative: Command shortcuts remain safe in its shell.
+  terminal_contexts: &terminal_contexts
+    - /(?i)ghostty/
+    - /(?i)gnome-terminal/
+    - /(?i)alacritty/
+    - /(?i)kitty/
+    - /(?i)konsole/
+    - /(?i)wezterm/
+    - /(?i)xfce4-terminal/
+    - /(?i)terminator/
+    - /(?i)tilix/
+    - /(?i)(^|\.)xterm$/
+    - /(?i)urxvt|rxvt/
+    - /(?i)(^|\.)foot$/
+    - /(?i)mate-terminal/
+    - /(?i)code|codium|jetbrains|idea|pycharm|webstorm|clion|goland|eclipse/
+  desktop_contexts: &desktop_contexts
+    - /(?i)firefox|chrome|chromium|brave/
+    - /(?i)nemo|nautilus|thunar|dolphin/
+    - /(?i)bitwarden|drawio|libreoffice/
+    - /(?i)slack|discord|teams|telegram/
+    - /(?i)thunderbird|evolution/
+    - /(?i)evince|xreader|okular/
+    - /(?i)steam|spotify|obsidian/
+  terminal_remap: &terminal_remap
+    Super-C: Ctrl-Shift-C
+    Super-V: Ctrl-Shift-V
+    Super-A: Ctrl-Shift-A
+    Super-F: Ctrl-Shift-F
+    Super-N: Ctrl-Shift-N
+    Super-T: Ctrl-Shift-T
+    Super-W: Ctrl-Shift-W
+    Super-Q: Ctrl-Shift-Q
+    Super-K: Ctrl-L
+    Super-Equal: Ctrl-Equal
+    Super-Minus: Ctrl-Minus
+    Super-0: Ctrl-0
+
 keymap:
   # Terminal emulators need their own clipboard/window actions. Sending Ctrl+C
   # here would interrupt the foreground process instead of copying text.
-  - name: macOS shortcuts in terminals
+  - name: macOS shortcuts in terminal contexts
     application:
-      only:
-        - /(?i)ghostty/
-        - /(?i)gnome-terminal/
-        - /(?i)alacritty/
-        - /(?i)kitty/
-        - /(?i)konsole/
-        - /(?i)wezterm/
+      only: *terminal_contexts
     exact_match: true
-    remap:
-      Super-C: Ctrl-Shift-C
-      Super-V: Ctrl-Shift-V
-      Super-A: Ctrl-Shift-A
-      Super-F: Ctrl-Shift-F
-      Super-N: Ctrl-Shift-N
-      Super-T: Ctrl-Shift-T
-      Super-W: Ctrl-Shift-W
-      Super-Q: Ctrl-Shift-Q
-      Super-K: Ctrl-L
-      Super-Equal: Ctrl-Equal
-      Super-Minus: Ctrl-Minus
-      Super-0: Ctrl-0
+    remap: *terminal_remap
 
-  # Normal Linux applications conventionally expose these actions through
-  # Ctrl. Terminal windows are excluded so shell control keys remain intact.
+  # Recognized desktop applications conventionally expose these actions through
+  # Ctrl. An allowlist makes unresolved and unfamiliar classes fail closed.
   - name: macOS shortcuts in desktop applications
     application:
-      not:
-        - /(?i)ghostty/
-        - /(?i)gnome-terminal/
-        - /(?i)alacritty/
-        - /(?i)kitty/
-        - /(?i)konsole/
-        - /(?i)wezterm/
+      only: *desktop_contexts
     exact_match: true
     remap:
       Super-A: Ctrl-A
@@ -66,3 +82,9 @@ keymap:
       Super-Equal: Ctrl-Equal
       Super-Minus: Ctrl-Minus
       Super-0: Ctrl-0
+
+  # First matching definition wins. Unknown classes and a temporarily missing
+  # _NET_ACTIVE_WINDOW reach this terminal-safe catch-all instead of Ctrl+C/Q/W.
+  - name: Terminal-safe fallback for unknown applications
+    exact_match: true
+    remap: *terminal_remap

--- a/xremap/start
+++ b/xremap/start
@@ -1,6 +1,8 @@
 #!/bin/sh
 # Xremap's application-aware X11 build must not capture the keyboard in another
 # desktop or under Cinnamon's experimental Wayland session.
+set -eu
+
 desktop=$(printf '%s' "${XDG_CURRENT_DESKTOP:-}" | tr '[:upper:]' '[:lower:]')
 case "$desktop" in
   *cinnamon*) ;;
@@ -9,23 +11,39 @@ esac
 
 [ "${XDG_SESSION_TYPE:-}" = x11 ] || exit 0
 
-device=/dev/input/by-id/usb-Logitech_USB_Receiver-event-kbd
-if [ ! -e "$device" ]; then
+sys_input=${XREMAP_SYS_INPUT:-/sys/class/input}
+dev_input=${XREMAP_DEV_INPUT:-/dev/input}
+pidfile="$HOME/.cache/xremap-supervisor.pid"
+mkdir -p "${pidfile%/*}"
+printf '%s\n' "$$" > "$pidfile"
+trap 'rm -f "$pidfile"' EXIT
+trap 'exit 0' HUP INT TERM
+
+while :; do
   device=
-  for name_file in /sys/class/input/event*/device/name; do
+  for name_file in "$sys_input"/event*/device/name; do
     [ -r "$name_file" ] || continue
     IFS= read -r name < "$name_file"
     if [ "$name" = "MX MCHNCL Keyboard" ]; then
       event_dir=${name_file%/device/name}
-      device=/dev/input/${event_dir##*/}
+      device=$dev_input/${event_dir##*/}
       break
     fi
   done
-fi
 
-[ -n "$device" ] || exit 0
+  if [ -z "$device" ]; then
+    sleep 2
+    continue
+  fi
 
-exec "$HOME/.local/bin/xremap" \
-  --device "$device" \
-  --watch=config,device \
-  "$HOME/.config/xremap/config.yml"
+  status=0
+  "$HOME/.local/bin/xremap" \
+    --device "$device" \
+    --watch=config \
+    "$HOME/.config/xremap/config.yml" || status=$?
+
+  # A disconnect makes xremap exit after its exact event path disappears. Scan
+  # again so a reconnected keyboard can use its newly assigned event number.
+  [ ! -e "$device" ] || exit "$status"
+  sleep 2
+done

--- a/xremap/start
+++ b/xremap/start
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Xremap's application-aware X11 build must not capture the keyboard in another
+# desktop or under Cinnamon's experimental Wayland session.
+desktop=$(printf '%s' "${XDG_CURRENT_DESKTOP:-}" | tr '[:upper:]' '[:lower:]')
+case "$desktop" in
+  *cinnamon*) ;;
+  *) exit 0 ;;
+esac
+
+[ "${XDG_SESSION_TYPE:-}" = x11 ] || exit 0
+
+exec "$HOME/.local/bin/xremap" \
+  --device "MX MCHNCL Keyboard" \
+  --watch=config,device \
+  "$HOME/.config/xremap/config.yml"

--- a/xremap/start
+++ b/xremap/start
@@ -9,7 +9,23 @@ esac
 
 [ "${XDG_SESSION_TYPE:-}" = x11 ] || exit 0
 
+device=/dev/input/by-id/usb-Logitech_USB_Receiver-event-kbd
+if [ ! -e "$device" ]; then
+  device=
+  for name_file in /sys/class/input/event*/device/name; do
+    [ -r "$name_file" ] || continue
+    IFS= read -r name < "$name_file"
+    if [ "$name" = "MX MCHNCL Keyboard" ]; then
+      event_dir=${name_file%/device/name}
+      device=/dev/input/${event_dir##*/}
+      break
+    fi
+  done
+fi
+
+[ -n "$device" ] || exit 0
+
 exec "$HOME/.local/bin/xremap" \
-  --device "MX MCHNCL Keyboard" \
+  --device "$device" \
   --watch=config,device \
   "$HOME/.config/xremap/config.yml"


### PR DESCRIPTION
## Summary

- add a pinned, checksummed xremap X11 binary and MX Mechanical-specific autostart configuration
- map exact Command-position (Super) shortcuts to Linux application actions, with terminal-safe clipboard/window mappings
- preserve Cinnamon, xbindkeys, and terminal control semantics; migrate only the four overlapping Cinnamon shortcuts
- provision explicit `input`/`uinput` permissions and document their keylogging-level security implications

## Safety decisions

- no blanket Alt/Super modifier swap
- Command+W and Command+Q are intentionally enabled, including immediate terminal close/quit behavior
- no remapping of Super+arrows, Super+Tab, Super+Space, Super+D/E, or Ctrl+Super tiling chords
- a supervisor selects only an event whose evdev name exactly equals `MX MCHNCL Keyboard`; it waits while absent and re-discovers after reconnect/renumber, never selecting the shared receiver
- recognized desktop classes get Ctrl-style actions; terminal/IDE, unknown, and temporarily unresolved classes fail closed to terminal-safe actions
- installation and autostart runtime are both restricted to Cinnamon/X11
- uinput uses xremap-specific module/udev filenames to avoid administrator-file collisions
- stopping `xremap` immediately restores normal Linux behavior

## Verification

- `ansible-playbook setup.yml --syntax-check`
- `ansible-lint tasks/desktop.yml setup.yml` (production profile, zero findings)
- `desktop-file-validate` on the rendered autostart entry
- xremap v0.15.11 archive SHA-256 verified against the release asset
- xremap config parsed by the release binary (startup reached the expected pre-install input-permission boundary)
- live xremap window-class output matched terminal and desktop allowlists; empty/unknown classes reached the terminal-safe fallback
- runtime wrapper tests covered Cinnamon/X11 gating, absent-device startup, reconnect, and event renumbering
- stat-guard tests covered regular-file, symlink, directory, and missing xremap paths
- playbook verifies the supervisor is alive and replaces a matching legacy directly launched xremap process
- live Cinnamon overlap audit confirmed only L/O/P/S overlap, all covered by migration
- `git diff --cached --check`

## First run

Run `ansible-playbook setup.yml -K --tags desktop`, then sign out and back in so the new `input` group membership is active.

## Relationship

PR #7 is merged; this successor PR targets `main`.
