### PR TITLE
feat: add a guided Omarchy customization installer

### DIFF
--- a/.github/workflows/test-setup-ci.yml
+++ b/.github/workflows/test-setup-ci.yml
@@ -93,6 +93,28 @@ jobs:
       - name: Desktop tasks resolve the Ubuntu series, not Mint's
         run: ansible-playbook .github/mint-release.yml
 
+  omarchy:
+    name: Omarchy boundaries and disposable HOME
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test tooling
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ansible zsh
+          ansible-galaxy collection install -r requirements.yml
+
+      - name: Static and syntax checks
+        run: |
+          bash tests/omarchy-boundaries.sh
+          bash -n bootstrap.sh tests/omarchy-boundaries.sh tests/omarchy-integration.sh
+          zsh -n omarchy/zsh/.zshrc omarchy/zsh/.zprofile omarchy/zsh/personal.zsh
+          ansible-playbook setup.yml --syntax-check
+
+      - name: Disposable-HOME integration
+        run: REQUIRE_ANSIBLE=1 bash tests/omarchy-integration.sh
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/test-setup-ci.yml
+++ b/.github/workflows/test-setup-ci.yml
@@ -102,18 +102,24 @@ jobs:
       - name: Test tooling
         run: |
           sudo apt-get update
-          sudo apt-get install -y ansible zsh
+          sudo apt-get install -y ansible shellcheck zsh
           ansible-galaxy collection install -r requirements.yml
 
       - name: Static and syntax checks
         run: |
           bash tests/omarchy-boundaries.sh
-          bash -n bootstrap.sh tests/omarchy-boundaries.sh tests/omarchy-integration.sh
+          bash -n bootstrap.sh install-omarchy.sh tests/omarchy-boundaries.sh \
+            tests/omarchy-integration.sh tests/omarchy-installer.sh
           zsh -n omarchy/zsh/.zshrc omarchy/zsh/.zprofile omarchy/zsh/personal.zsh
           ansible-playbook setup.yml --syntax-check
+          shellcheck bootstrap.sh install-omarchy.sh tests/omarchy-boundaries.sh \
+            tests/omarchy-integration.sh tests/omarchy-installer.sh \
+            tests/fixtures/omarchy/bin/omarchy
 
       - name: Disposable-HOME integration
-        run: REQUIRE_ANSIBLE=1 bash tests/omarchy-integration.sh
+        run: |
+          REQUIRE_ANSIBLE=1 bash tests/omarchy-integration.sh
+          bash tests/omarchy-installer.sh
 
   lint:
     name: Lint

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Dotfiles
 
-Terminal setup for macOS and Debian/Ubuntu (incl. Linux Mint), installed and kept in sync by one Ansible playbook.
+Terminal setup for macOS, Debian/Ubuntu (including Linux Mint), and opt-in Omarchy, kept in sync by one Ansible playbook.
 
 ## Features
 
-- 🚀 **One-command setup** - `./bootstrap.sh` installs Ansible and runs the playbook
+- 🚀 **One-command legacy setup** - `./bootstrap.sh` installs Ansible and runs the playbook on macOS/Debian
 - 🛡️ **Safe installation** - Automatic backups before overwriting existing configs
 - 🔁 **Idempotent** - Re-run any time; a second run reports `changed=0`
 - 📦 **Modern CLI tools** - Curated collection of productivity-enhancing utilities
@@ -34,6 +34,95 @@ ansible-playbook setup.yml       # macOS
 The run also creates `~/.secrets` (mode 600) from a template of placeholder tokens, which `.zprofile`
 sources on login — fill in the ones you use. It is written only when missing, so re-runs never
 overwrite it.
+
+## Omarchy (opt-in)
+
+Omarchy support is an adapter, not a replacement desktop configuration. It leaves Omarchy's Hyprland,
+keybindings, bar, theme, Foot, Neovim, tmux, Bash loader, and canonical Starship file untouched. The adapter
+only installs the allowlisted `omarchy-zsh` and `yazi` packages, adds the official Zsh loaders followed by a
+personal overlay, selects this repository's Starship config in Zsh through `STARSHIP_CONFIG`, and links the
+Yazi config. The adapter is tagged `never`, so an untagged playbook run cannot apply it.
+
+Do not use `bootstrap.sh` on Omarchy. Ansible is a prerequisite; after separate package-install approval it
+can be installed with:
+
+```bash
+omarchy pkg add ansible
+```
+
+Capture the current Omarchy-owned state and choose a rollback directory before any authorized apply:
+
+```bash
+baseline=$(mktemp -d)
+omarchy menu keybindings --print > "$baseline/keybindings.before"
+sha256sum ~/.config/hypr/hyprland.lua ~/.config/hypr/bindings.lua > "$baseline/hypr.before"
+sha256sum ~/.config/omarchy/shell.json ~/.config/foot/foot.ini \
+  ~/.config/nvim/init.lua ~/.config/tmux/tmux.conf > "$baseline/owned.before"
+omarchy theme current > "$baseline/theme.before"
+rollback="$HOME/.dotfiles_backup/omarchy-$(date +%Y%m%d-%H%M%S)"
+```
+
+Dry-run first, then apply only after reviewing the diff. The adapter supports the concise forms below:
+
+```bash
+ansible-playbook setup.yml -K --tags omarchy --check --diff
+ansible-playbook setup.yml -K --tags omarchy
+```
+
+For a controlled rollback, use the explicit directory captured above for both runs:
+
+```bash
+ansible-playbook setup.yml -K -e backup_dir="$rollback" --tags omarchy --check --diff
+ansible-playbook setup.yml -K -e backup_dir="$rollback" --tags omarchy
+
+# Later config-only reruns never perform package actions.
+ansible-playbook setup.yml --tags omarchy_config
+```
+
+Validate that Omarchy-owned surfaces did not move, the shell tools are available, and a second adapter run
+reports `changed=0`:
+
+```bash
+omarchy menu keybindings --print > "$baseline/keybindings.after"
+cmp "$baseline/keybindings.before" "$baseline/keybindings.after"
+sha256sum ~/.config/hypr/hyprland.lua ~/.config/hypr/bindings.lua > "$baseline/hypr.after"
+cmp "$baseline/hypr.before" "$baseline/hypr.after"
+sha256sum ~/.config/omarchy/shell.json ~/.config/foot/foot.ini \
+  ~/.config/nvim/init.lua ~/.config/tmux/tmux.conf > "$baseline/owned.after"
+cmp "$baseline/owned.before" "$baseline/owned.after"
+omarchy theme current > "$baseline/theme.after"
+cmp "$baseline/theme.before" "$baseline/theme.after"
+test -z "$(hyprctl configerrors)"
+pacman -Q omarchy-zsh yazi
+zsh -lic 'test "$STARSHIP_CONFIG" = "$HOME/.config/dotfiles/starship.toml"'
+ansible-playbook setup.yml -K -e backup_dir="$rollback" --tags omarchy
+```
+
+Zsh activation remains manual and requires separate approval. If `omarchy-setup-zsh` is later chosen, first
+back up `.bashrc` and `.inputrc`; the official command replaces `.zshrc`, so rerun
+`ansible-playbook setup.yml --tags omarchy_config` afterward. The adapter never runs that command or `chsh`.
+
+### Omarchy rollback
+
+Rollback does not require removing packages. Using the exact directory passed as `backup_dir`, remove only
+`.zshrc`, `.zprofile`, `.config/dotfiles/zsh/personal.zsh`, `.config/dotfiles/starship.toml`, and
+`.config/yazi`; then restore the corresponding `.bak` entries from that directory only where a pre-apply
+target existed. Start a fresh Bash shell and repeat the keybinding, Hyprland, owner-file, and theme
+comparisons above. Package removal is a separate approval because dependency removal may be destructive.
+If `omarchy-setup-zsh` was run separately, also restore its exact pre-activation `.bashrc` and `.inputrc`
+backups.
+
+Repository-only validation is safe on any development host:
+
+```bash
+bash tests/omarchy-boundaries.sh
+REQUIRE_ANSIBLE=1 bash tests/omarchy-integration.sh
+ansible-playbook setup.yml --syntax-check
+zsh -n omarchy/zsh/.zshrc omarchy/zsh/.zprofile omarchy/zsh/personal.zsh
+```
+
+The integration test uses a disposable HOME, fixture marker paths, and a mock Omarchy command. It never
+writes under `/usr/share/omarchy` or invokes a real package manager.
 
 ## What's Included
 
@@ -81,6 +170,8 @@ overwrite it.
 | Just the symlinks / fonts / tmux / secrets | `ansible-playbook setup.yml --tags symlinks` (or `fonts`, `tmux`, `secrets`) |
 | Skip the 1.4 GB ollama build (Linux) | `ansible-playbook setup.yml -K --skip-tags ollama` |
 | Linux desktop: Ulauncher, Ghostty, Bitwarden, draw.io, Flameshot, Cinnamon hot corners/hotkeys, xbindkeys | `ansible-playbook setup.yml -K --tags desktop` (never runs unless asked; needs a graphical session) |
+| Omarchy adapter | `ansible-playbook setup.yml -K --tags omarchy` (never runs unless asked) |
+| Omarchy config only | `ansible-playbook setup.yml --tags omarchy_config` |
 | Dry run (on an already set-up machine; `-K` on Linux) | `ansible-playbook setup.yml --check --diff` |
 | Verify | Run it again and expect `changed=0` |
 
@@ -104,10 +195,12 @@ Existing files in the way of a symlink are moved to `~/.dotfiles_backup/<timesta
 ├── tasks/
 │   ├── symlinks.yml      # Backup-then-link
 │   ├── debian.yml        # apt, zsh login shell, Homebrew on Linux, ollama
+│   ├── omarchy.yml       # Opt-in Omarchy package/config adapter
 │   └── desktop.yml       # Linux desktop apps and Cinnamon settings (--tags desktop)
 ├── vars/
 │   ├── Darwin.yml        # macOS paths
-│   └── Debian.yml        # Linux paths, apt packages, brew exclusions
+│   ├── Debian.yml        # Linux paths, apt packages, brew exclusions
+│   └── Omarchy.yml       # Exact package and managed-path allowlists
 ├── brew_packages.yml     # Homebrew formulae & casks
 ├── .github/              # CI workflow, plus the Mint release-resolution play it runs
 ├── .config/              # Modern tool configs
@@ -118,6 +211,8 @@ Existing files in the way of a symlink are moved to `~/.dotfiles_backup/<timesta
 │   ├── sheldon/          # Zsh plugin manager
 │   └── yazi/             # Terminal file manager
 ├── zsh/                  # .zprofile, .zshrc, .zshrc.core
+├── omarchy/zsh/          # Official-loader integration and personal overlay
+├── tests/                # Omarchy policy and disposable-HOME checks
 ├── tmux/                 # .tmux.conf
 ├── claude/               # Linked into ~/.claude: CLAUDE.md, AGENTS.md, settings, commands, skills
 ├── codex/                # Linked into ~/.codex: AGENTS.md, instructions, rules, keybindings
@@ -130,7 +225,7 @@ Existing files are backed up to `~/.dotfiles_backup/` with timestamps.
 
 ## Requirements
 
-- macOS, or a Debian/Ubuntu-based Linux (apt); sudo on Linux
+- macOS, Debian/Ubuntu-based Linux (apt), or Omarchy; sudo on Linux
 - Internet connection for package downloads
 
 ## Development
@@ -142,8 +237,9 @@ shellcheck bootstrap.sh
 ```
 
 CI runs `bootstrap.sh` and the playbook on macOS and Ubuntu, then runs the playbook a second time and fails
-unless it reports `changed=0`. A third job checks the Linux Mint release resolution the desktop tasks depend
-on, which no runner can cover directly.
+unless it reports `changed=0`. Other jobs check Linux Mint release resolution, static Omarchy boundaries,
+and the Omarchy adapter against a disposable HOME and mock package command. No hosted runner provides a live
+Omarchy/Hyprland session, so compositor, key-dispatch, theme, and reboot/login checks remain real-host gates.
 
 ## Customization
 

--- a/README.md
+++ b/README.md
@@ -19,110 +19,110 @@ Terminal setup for macOS, Debian/Ubuntu (including Linux Mint), and opt-in Omarc
 git clone https://github.com/yordan-kanchelov/dotfiles.git ~/dotfiles
 cd ~/dotfiles
 
-# Installs Ansible (and Homebrew on macOS), then runs setup.yml.
-# On Linux it asks for your sudo password (apt, login shell).
+# macOS/Debian only: installs prerequisites, then runs setup.yml.
+# Omarchy users should continue with the guided section below.
 ./bootstrap.sh
 ```
 
-Afterwards, re-run the playbook directly:
+On macOS/Debian, re-run the playbook directly:
 
 ```bash
 ansible-playbook setup.yml -K    # Linux
 ansible-playbook setup.yml       # macOS
 ```
 
-The run also creates `~/.secrets` (mode 600) from a template of placeholder tokens, which `.zprofile`
+The macOS/Debian run also creates `~/.secrets` (mode 600) from a template of placeholder tokens, which `.zprofile`
 sources on login — fill in the ones you use. It is written only when missing, so re-runs never
 overwrite it.
 
-## Omarchy (opt-in)
+## Omarchy (guided and opt-in)
 
-Omarchy support is an adapter, not a replacement desktop configuration. It leaves Omarchy's Hyprland,
-keybindings, bar, theme, Foot, Neovim, tmux, Bash loader, and canonical Starship file untouched. The adapter
-only installs the allowlisted `omarchy-zsh` and `yazi` packages, adds the official Zsh loaders followed by a
-personal overlay, selects this repository's Starship config in Zsh through `STARSHIP_CONFIG`, and links the
-Yazi config. The adapter is tagged `never`, so an untagged playbook run cannot apply it.
-
-Do not use `bootstrap.sh` on Omarchy. Ansible is a prerequisite; after separate package-install approval it
-can be installed with:
+Omarchy uses a two-step flow. `bootstrap.sh` detects `ID=omarchy`, ensures only Ansible through the public
+Omarchy CLI, installs the existing `community.general` requirement when missing, prints the next command,
+and exits without running `setup.yml`. The existing macOS/Debian bootstrap behavior is unchanged.
 
 ```bash
-omarchy pkg add ansible
+./bootstrap.sh
+./install-omarchy.sh
+./install-omarchy.sh --dry-run
+./install-omarchy.sh --non-interactive --yes
+./install-omarchy.sh --non-interactive --yes \
+  --components zsh,yazi \
+  --optional-tools shellcheck,git-lfs,glow \
+  --node-manager mise --config yes
 ```
 
-Capture the current Omarchy-owned state and choose a rollback directory before any authorized apply:
+The guided installer uses Gum and prints a complete plan before confirmation. Deterministic runs accept only
+the documented component, tool, Node-manager, config, backup, confirmation, and dry-run flags; arbitrary
+package names are rejected.
+
+### Defaults and optional tools
+
+The default plan selects the Zsh overlay, Yazi, and ShellCheck, preserves the active Mise-managed Node, and
+applies config. The fixed optional trusted-repository tools are `git-lfs`, `glow`, `viu`, `act`, and
+`pandoc-cli`. Packages already listed in the local Omarchy base manifest or already installed are skipped.
+All missing selected packages are passed in stable order to one `omarchy pkg add` call.
+
+The repository Starship file is linked to `~/.config/dotfiles/starship.toml` and selected only in Zsh through
+`STARSHIP_CONFIG`; Omarchy's canonical `~/.config/starship.toml` remains untouched. The official Omarchy
+environment and Zsh loaders run before the personal overlay. Yazi is the only overlapping application config
+directory linked by the adapter.
+
+### Why fnm is not the default
+
+Omarchy already owns Node through Mise. The default preserves the active Mise Node instead of replacing it
+with the repository's historical Node 22 choice. `fnm` is visible only as an advanced, mutually exclusive
+selection. The installer refuses fnm while `mise where node` resolves, and refuses the Mise path while fnm is
+present. Switching to fnm is a separate manual boundary: back up Mise config, obtain explicit approval before
+running the printed `mise unuse --global node@VERSION --no-prune` command, start a fresh shell, verify
+`mise where node` fails, and rerun with `--node-manager fnm --fnm-node 22`.
+
+### Configuration, receipt, and rollback
+
+Ansible is config-only on Omarchy. The `omarchy_config` tag remains paired with `never`; the installer passes component booleans
+and a validated backup directory:
 
 ```bash
-baseline=$(mktemp -d)
-omarchy menu keybindings --print > "$baseline/keybindings.before"
-sha256sum ~/.config/hypr/hyprland.lua ~/.config/hypr/bindings.lua > "$baseline/hypr.before"
-sha256sum ~/.config/omarchy/shell.json ~/.config/foot/foot.ini \
-  ~/.config/nvim/init.lua ~/.config/tmux/tmux.conf > "$baseline/owned.before"
-omarchy theme current > "$baseline/theme.before"
-rollback="$HOME/.dotfiles_backup/omarchy-$(date +%Y%m%d-%H%M%S)"
-```
-
-Dry-run first, then apply only after reviewing the diff. The adapter supports the concise forms below:
-
-```bash
-ansible-playbook setup.yml -K --tags omarchy --check --diff
-ansible-playbook setup.yml -K --tags omarchy
-```
-
-For a controlled rollback, use the explicit directory captured above for both runs:
-
-```bash
-ansible-playbook setup.yml -K -e backup_dir="$rollback" --tags omarchy --check --diff
-ansible-playbook setup.yml -K -e backup_dir="$rollback" --tags omarchy
-
-# Later config-only reruns never perform package actions.
 ansible-playbook setup.yml --tags omarchy_config
 ```
 
-Validate that Omarchy-owned surfaces did not move, the shell tools are available, and a second adapter run
-reports `changed=0`:
+A confirmed run writes `$backup_dir/omarchy-install.receipt` before mutation. It records selections, package
+planning, Node detection/action, Ansible variables, exact commands, and statuses. `--dry-run` prints the same
+plan and receipt content plus the Ansible `--check --diff` command, but writes no receipt and runs no mutating
+command.
 
-```bash
-omarchy menu keybindings --print > "$baseline/keybindings.after"
-cmp "$baseline/keybindings.before" "$baseline/keybindings.after"
-sha256sum ~/.config/hypr/hyprland.lua ~/.config/hypr/bindings.lua > "$baseline/hypr.after"
-cmp "$baseline/hypr.before" "$baseline/hypr.after"
-sha256sum ~/.config/omarchy/shell.json ~/.config/foot/foot.ini \
-  ~/.config/nvim/init.lua ~/.config/tmux/tmux.conf > "$baseline/owned.after"
-cmp "$baseline/owned.before" "$baseline/owned.after"
-omarchy theme current > "$baseline/theme.after"
-cmp "$baseline/theme.before" "$baseline/theme.after"
-test -z "$(hyprctl configerrors)"
-pacman -Q omarchy-zsh yazi
-zsh -lic 'test "$STARSHIP_CONFIG" = "$HOME/.config/dotfiles/starship.toml"'
-ansible-playbook setup.yml -K -e backup_dir="$rollback" --tags omarchy
-```
+Configuration rollback removes only `.zshrc`, `.zprofile`,
+`.config/dotfiles/zsh/personal.zsh`, `.config/dotfiles/starship.toml`, and `.config/yazi`, then restores the
+corresponding `.bak` entries from the receipt's backup directory where a pre-install target existed. There is
+no automated package or Node rollback.
 
-Zsh activation remains manual and requires separate approval. If `omarchy-setup-zsh` is later chosen, first
-back up `.bashrc` and `.inputrc`; the official command replaces `.zshrc`, so rerun
-`ansible-playbook setup.yml --tags omarchy_config` afterward. The adapter never runs that command or `chsh`.
+Zsh activation remains manual. The installer never runs `omarchy-setup-zsh` or `chsh`; if separately
+approved, back up `.bashrc` and `.inputrc`, run the official setup, then rerun the config-only Ansible tag
+because the official setup replaces `.zshrc`.
 
-### Omarchy rollback
+### Ownership and deferred scope
 
-Rollback does not require removing packages. Using the exact directory passed as `backup_dir`, remove only
-`.zshrc`, `.zprofile`, `.config/dotfiles/zsh/personal.zsh`, `.config/dotfiles/starship.toml`, and
-`.config/yazi`; then restore the corresponding `.bak` entries from that directory only where a pre-apply
-target existed. Start a fresh Bash shell and repeat the keybinding, Hyprland, owner-file, and theme
-comparisons above. Package removal is a separate approval because dependency removal may be destructive.
-If `omarchy-setup-zsh` was run separately, also restore its exact pre-activation `.bashrc` and `.inputrc`
-backups.
+Omarchy retains Hyprland, tiling and all bindings, shell/bar JSON and Quickshell, the current theme, Foot,
+Ghostty, Neovim/LazyVim, tmux, Atuin, Sheldon, fonts, and the Bash loader. Nothing writes beneath
+`/usr/share/omarchy`. The installer does not port Mint, apt, Homebrew/Linuxbrew, font, TPM, broad legacy-link,
+secrets, Ollama, or Cinnamon/X11 behavior.
 
-Repository-only validation is safe on any development host:
+Explicitly deferred are AWS, Ollama, terminal switching, AUR/API/load tools, arbitrary packages, other dev
+environments, Atuin/Sheldon, Ghostty config, and package removal.
+
+Repository validation:
 
 ```bash
 bash tests/omarchy-boundaries.sh
 REQUIRE_ANSIBLE=1 bash tests/omarchy-integration.sh
+bash tests/omarchy-installer.sh
 ansible-playbook setup.yml --syntax-check
 zsh -n omarchy/zsh/.zshrc omarchy/zsh/.zprofile omarchy/zsh/personal.zsh
 ```
 
-The integration test uses a disposable HOME, fixture marker paths, and a mock Omarchy command. It never
-writes under `/usr/share/omarchy` or invokes a real package manager.
+Tests use fixture Omarchy paths, command mocks, and disposable HOME directories. They do not prove live
+Hyprland/compositor behavior, graphical key dispatch, login/reboot behavior, or compatibility after a future
+Omarchy update.
 
 ## What's Included
 
@@ -170,12 +170,13 @@ writes under `/usr/share/omarchy` or invokes a real package manager.
 | Just the symlinks / fonts / tmux / secrets | `ansible-playbook setup.yml --tags symlinks` (or `fonts`, `tmux`, `secrets`) |
 | Skip the 1.4 GB ollama build (Linux) | `ansible-playbook setup.yml -K --skip-tags ollama` |
 | Linux desktop: Ulauncher, Ghostty, Bitwarden, draw.io, Flameshot, Cinnamon hot corners/hotkeys, xbindkeys | `ansible-playbook setup.yml -K --tags desktop` (never runs unless asked; needs a graphical session) |
-| Omarchy adapter | `ansible-playbook setup.yml -K --tags omarchy` (never runs unless asked) |
+| Guided Omarchy setup | `./bootstrap.sh`, then `./install-omarchy.sh` |
 | Omarchy config only | `ansible-playbook setup.yml --tags omarchy_config` |
 | Dry run (on an already set-up machine; `-K` on Linux) | `ansible-playbook setup.yml --check --diff` |
 | Verify | Run it again and expect `changed=0` |
 
-`./bootstrap.sh` passes extra arguments through, so `./bootstrap.sh --tags symlinks` works too.
+On macOS/Debian, `./bootstrap.sh` passes extra arguments through, so `./bootstrap.sh --tags symlinks` works.
+The Omarchy prerequisite-only path rejects arguments and points to `install-omarchy.sh`.
 
 Existing files in the way of a symlink are moved to `~/.dotfiles_backup/<timestamp>/` first. There is no interactive prompting — the playbook always backs up, then links.
 
@@ -189,18 +190,19 @@ Existing files in the way of a symlink are moved to `~/.dotfiles_backup/<timesta
 ### Directory Structure
 ```
 .
-├── bootstrap.sh          # Installs Ansible, runs setup.yml
+├── bootstrap.sh          # Legacy setup; Omarchy prerequisite-only path
+├── install-omarchy.sh    # Guided Omarchy package/Node/config installer
 ├── setup.yml             # The playbook: symlink allowlist, package/font/tmux/secrets tasks
 ├── requirements.yml      # The community.general collection the playbook needs
 ├── tasks/
 │   ├── symlinks.yml      # Backup-then-link
 │   ├── debian.yml        # apt, zsh login shell, Homebrew on Linux, ollama
-│   ├── omarchy.yml       # Opt-in Omarchy package/config adapter
+│   ├── omarchy.yml       # Opt-in Omarchy config-only adapter
 │   └── desktop.yml       # Linux desktop apps and Cinnamon settings (--tags desktop)
 ├── vars/
 │   ├── Darwin.yml        # macOS paths
 │   ├── Debian.yml        # Linux paths, apt packages, brew exclusions
-│   └── Omarchy.yml       # Exact package and managed-path allowlists
+│   └── Omarchy.yml       # Exact config managed-path allowlist
 ├── brew_packages.yml     # Homebrew formulae & casks
 ├── .github/              # CI workflow, plus the Mint release-resolution play it runs
 ├── .config/              # Modern tool configs
@@ -233,12 +235,14 @@ Existing files are backed up to `~/.dotfiles_backup/` with timestamps.
 ```bash
 ansible-playbook setup.yml --syntax-check
 ansible-lint                     # with ansible-core: ansible-galaxy collection install -r requirements.yml first
-shellcheck bootstrap.sh
+shellcheck bootstrap.sh install-omarchy.sh tests/omarchy-*.sh
+bash tests/omarchy-boundaries.sh
+bash tests/omarchy-installer.sh
 ```
 
 CI runs `bootstrap.sh` and the playbook on macOS and Ubuntu, then runs the playbook a second time and fails
 unless it reports `changed=0`. Other jobs check Linux Mint release resolution, static Omarchy boundaries,
-and the Omarchy adapter against a disposable HOME and mock package command. No hosted runner provides a live
+and the Omarchy adapter/installer against disposable HOME directories and mock commands. No hosted runner provides a live
 Omarchy/Hyprland session, so compositor, key-dispatch, theme, and reboot/login checks remain real-host gates.
 
 ## Customization

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,8 +1,40 @@
 #!/bin/bash
-# Installs Ansible (and Homebrew on macOS), then runs setup.yml. Extra arguments
-# go straight to ansible-playbook:  ./bootstrap.sh --tags symlinks
+# Installs prerequisites, then runs setup.yml on macOS/Debian. On Omarchy it
+# prepares Ansible only; install-omarchy.sh owns selection and configuration.
 set -euo pipefail
 cd "$(dirname "$0")"
+
+ensure_collection() {
+  # pip/pipx ansible-core ships without community.general; apt/brew's `ansible` bundles it.
+  # grep without -q drains the pipe, avoiding a pipefail/EPIPE false miss.
+  ansible-galaxy collection list community.general 2>/dev/null | grep '^community.general ' >/dev/null ||
+    ansible-galaxy collection install -r requirements.yml
+}
+
+os_release=${DOTFILES_OS_RELEASE:-/etc/os-release}
+os_id=
+os_like=
+if [[ -r $os_release ]]; then
+  # The path is fixed by the OS or an explicit test seam.
+  # shellcheck disable=SC1090
+  source "$os_release"
+  os_id=${ID:-}
+  os_like=${ID_LIKE:-}
+fi
+
+if [[ $os_id == omarchy ]]; then
+  (($# == 0)) || { echo "Omarchy bootstrap accepts no arguments; use ./install-omarchy.sh" >&2; exit 1; }
+  command -v omarchy >/dev/null || { echo "Omarchy public CLI is missing; repair Omarchy first" >&2; exit 1; }
+  [[ -f ${OMARCHY_PATH:-/usr/share/omarchy}/default/hypr/bootstrap.lua ]] || {
+    echo "Omarchy bootstrap marker is missing; repair Omarchy first" >&2
+    exit 1
+  }
+  command -v ansible-playbook >/dev/null || omarchy pkg add ansible
+  command -v ansible-playbook >/dev/null || { echo "Ansible installation failed" >&2; exit 1; }
+  ensure_collection
+  echo "Prerequisites ready. Next: ./install-omarchy.sh"
+  exit 0
+fi
 
 case "$OSTYPE" in
   darwin*)
@@ -13,6 +45,10 @@ case "$OSTYPE" in
     command -v ansible-playbook >/dev/null || brew install ansible
     ;;
   linux-gnu*)
+    case " $os_id $os_like " in
+      *debian*|*ubuntu*|*linuxmint*) ;;
+      *) echo "Debian/Ubuntu or Omarchy only" >&2; exit 1 ;;
+    esac
     command -v apt-get >/dev/null || { echo "Debian/Ubuntu only" >&2; exit 1; }
     if ! command -v ansible-playbook >/dev/null; then
       sudo apt-get update -y && sudo apt-get install -y ansible
@@ -27,10 +63,5 @@ case "$OSTYPE" in
     ;;
 esac
 
-# pip/pipx ansible-core ships without community.general; apt/brew's `ansible` bundles it.
-# grep without -q: it must drain the pipe, or pipefail can turn ansible-galaxy's
-# EPIPE into a bogus miss that reinstalls the collection every run.
-ansible-galaxy collection list community.general 2>/dev/null | grep '^community.general ' >/dev/null ||
-  ansible-galaxy collection install -r requirements.yml
-
+ensure_collection
 exec ansible-playbook setup.yml "$@"

--- a/install-omarchy.sh
+++ b/install-omarchy.sh
@@ -374,9 +374,11 @@ fi
 mkdir -p "$backup_dir"
 write_receipt_header > "$receipt"
 run_recorded() {
-  printf 'command:' >> "$receipt"
-  printf ' %q' "$@" >> "$receipt"
-  printf '\n' >> "$receipt"
+  {
+    printf 'command:'
+    printf ' %q' "$@"
+    printf '\n'
+  } >> "$receipt"
   set +e
   "$@"
   status=$?

--- a/install-omarchy.sh
+++ b/install-omarchy.sh
@@ -1,0 +1,410 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$repo"
+
+die() { printf 'Error: %s\n' "$*" >&2; exit 1; }
+usage() {
+  cat <<'EOF'
+Usage: ./install-omarchy.sh [options]
+
+  --components zsh,yazi|zsh|yazi|none
+  --optional-tools shellcheck,git-lfs,glow,viu,act,pandoc-cli|none
+  --node-manager mise|fnm
+  --fnm-node VERSION
+  --config yes|no
+  --backup-dir ABSOLUTE_PATH
+  --non-interactive
+  --yes
+  --dry-run
+  --help
+EOF
+}
+
+components_csv=zsh,yazi
+optional_csv=shellcheck
+node_manager=mise
+fnm_node=
+config=yes
+backup_dir=
+non_interactive=false
+assume_yes=false
+dry_run=false
+declare -A seen=()
+
+set_option() {
+  local name=$1 value=$2
+  if [[ ${seen[$name]+set} && ${seen[$name]} != "$value" ]]; then
+    die "conflicting duplicate --${name//_/-} values"
+  fi
+  seen[$name]=$value
+  printf -v "$name" '%s' "$value"
+}
+
+while (($#)); do
+  case $1 in
+    --components|--optional-tools|--node-manager|--fnm-node|--config|--backup-dir)
+      (($# >= 2)) || die "$1 requires a value"
+      value=$2
+      case $1 in
+        --components) set_option components_csv "$value" ;;
+        --optional-tools) set_option optional_csv "$value" ;;
+        --node-manager) set_option node_manager "$value" ;;
+        --fnm-node) set_option fnm_node "$value" ;;
+        --config) set_option config "$value" ;;
+        --backup-dir) set_option backup_dir "$value" ;;
+      esac
+      shift 2
+      ;;
+    --non-interactive) non_interactive=true; shift ;;
+    --yes) assume_yes=true; shift ;;
+    --dry-run) dry_run=true; shift ;;
+    --help) usage; exit 0 ;;
+    --*) die "unknown option: $1" ;;
+    *) die "positional arguments are not supported: $1" ;;
+  esac
+done
+
+validate_csv() {
+  local value=$1 kind=$2 item allowed allowed_value duplicate
+  shift 2
+  local -a allowed_values=("$@") raw=()
+  local -A found=()
+  [[ -n $value ]] || die "$kind cannot be empty"
+  if [[ $value == none ]]; then
+    return
+  fi
+  [[ $value != *none* ]] || die "$kind cannot combine none with another value"
+  IFS=, read -r -a raw <<< "$value"
+  ((${#raw[@]})) || die "$kind cannot be empty"
+  for item in "${raw[@]}"; do
+    allowed=false
+    for allowed_value in "${allowed_values[@]}"; do
+      [[ $item == "$allowed_value" ]] && allowed=true
+    done
+    $allowed || die "invalid $kind value: $item"
+    duplicate=${found[$item]:-false}
+    $duplicate && die "duplicate $kind value: $item"
+    found[$item]=true
+  done
+}
+
+validate_csv "$components_csv" components zsh yazi
+validate_csv "$optional_csv" optional-tools shellcheck git-lfs glow viu act pandoc-cli
+[[ $node_manager == mise || $node_manager == fnm ]] || die "invalid node manager: $node_manager"
+[[ $config == yes || $config == no ]] || die "config must be yes or no"
+[[ -z $fnm_node || $node_manager == fnm ]] || die "--fnm-node requires --node-manager fnm"
+[[ -z $fnm_node || $fnm_node =~ ^[0-9]+([.][0-9]+){0,2}$ ]] || die "invalid fnm Node version: $fnm_node"
+if $non_interactive && ! $dry_run && ! $assume_yes; then
+  die "mutating --non-interactive runs require --yes"
+fi
+if $non_interactive && [[ $node_manager == fnm && -z $fnm_node ]]; then
+  die "non-interactive fnm selection requires --fnm-node"
+fi
+
+os_release=${DOTFILES_OS_RELEASE:-/etc/os-release}
+[[ -r $os_release ]] || die "cannot read $os_release"
+ID=
+# Fixed OS path or explicit test seam.
+# shellcheck disable=SC1090
+source "$os_release"
+[[ ${ID:-} == omarchy ]] || die "install-omarchy.sh requires ID=omarchy"
+omarchy_path=${OMARCHY_PATH:-/usr/share/omarchy}
+base_manifest="$omarchy_path/install/omarchy-base.packages"
+[[ -f $omarchy_path/default/hypr/bootstrap.lua ]] || die "Omarchy bootstrap marker is missing"
+command -v omarchy >/dev/null || die "Omarchy public CLI is missing"
+[[ -r $base_manifest ]] || die "Omarchy base package manifest is missing: $base_manifest"
+command -v ansible-playbook >/dev/null || die "Ansible is missing; run ./bootstrap.sh first"
+
+backup_root=$(realpath -m "$HOME/.dotfiles_backup")
+if [[ -z $backup_dir ]]; then
+  backup_dir="$backup_root/omarchy-$(date +%Y%m%d-%H%M%S)"
+fi
+[[ $backup_dir == /* ]] || die "--backup-dir must be absolute"
+backup_dir=$(realpath -m "$backup_dir")
+[[ $backup_dir == "$backup_root"/* ]] || die "--backup-dir must be beneath $backup_root"
+receipt="$backup_dir/omarchy-install.receipt"
+
+mise_node_path=
+if command -v mise >/dev/null && mise_node_path=$(mise where node 2>/dev/null); then
+  mise_active=true
+else
+  mise_active=false
+  mise_node_path=none
+fi
+if omarchy pkg present fnm >/dev/null 2>&1 || command -v fnm >/dev/null 2>&1; then
+  fnm_present=true
+else
+  fnm_present=false
+fi
+
+catalog=(omarchy-zsh yazi shellcheck git-lfs glow viu act pandoc-cli fnm)
+base_owns() {
+  local package=$1
+  awk -v package="$package" '
+    { sub(/[[:space:]]*#.*/, ""); gsub(/^[[:space:]]+|[[:space:]]+$/, "") }
+    $0 == package { found=1 }
+    END { exit found ? 0 : 1 }
+  ' "$base_manifest"
+}
+
+gum=${DOTFILES_GUM:-gum}
+if ! $non_interactive; then
+  command -v "$gum" >/dev/null || die "Gum is missing; repair Omarchy or use --non-interactive --yes"
+
+  printf 'Target: %s\nBase manifest: %s\n' "$omarchy_path" "$base_manifest"
+  for package in "${catalog[@]}"; do
+    if base_owns "$package"; then
+      state=base-owned
+    elif omarchy pkg present "$package" >/dev/null 2>&1; then
+      state=present
+    else
+      state=missing
+    fi
+    printf 'Package %-14s %s\n' "$package" "$state"
+  done
+  if $mise_active; then
+    printf 'Active Node owner: Mise (%s)\n' "$mise_node_path"
+  else
+    printf 'Active Node owner: none detected\n'
+  fi
+  for target in .zshrc .zprofile .config/dotfiles/zsh/personal.zsh \
+    .config/dotfiles/starship.toml .config/yazi; do
+    if [[ -e $HOME/$target || -L $HOME/$target ]]; then
+      state=present
+    else
+      state=absent
+    fi
+    printf 'Config target %-43s %s\n' "$HOME/$target" "$state"
+  done
+
+  if ! choice=$("$gum" choose --no-limit --header 'Core defaults' --selected 'Zsh overlay' --selected Yazi \
+    'Zsh overlay' Yazi); then
+    die "component selection cancelled"
+  fi
+  components_csv=none
+  if grep -Fxq 'Zsh overlay' <<< "$choice"; then
+    components_csv=zsh
+  fi
+  if grep -Fxq Yazi <<< "$choice"; then
+    if [[ $components_csv == none ]]; then
+      components_csv=yazi
+    else
+      components_csv+=,yazi
+    fi
+  fi
+
+  if ! choice=$("$gum" choose --no-limit --header 'Optional tools' --selected ShellCheck \
+    ShellCheck git-lfs glow viu act pandoc-cli); then
+    die "optional-tool selection cancelled"
+  fi
+  optional_csv=none
+  for label in ShellCheck git-lfs glow viu act pandoc-cli; do
+    if grep -Fxq "$label" <<< "$choice"; then
+      package=${label/ShellCheck/shellcheck}
+      if [[ $optional_csv == none ]]; then
+        optional_csv=$package
+      else
+        optional_csv+=,$package
+      fi
+    fi
+  done
+
+  if ! choice=$("$gum" choose --header 'Node manager' \
+    'Mise — recommended; preserve current Node' 'fnm — advanced; mutually exclusive'); then
+    die "Node manager selection cancelled"
+  fi
+  case $choice in
+    'Mise — recommended; preserve current Node') node_manager=mise ;;
+    'fnm — advanced; mutually exclusive') node_manager=fnm ;;
+    *) die "invalid Gum Node selection" ;;
+  esac
+
+  if [[ $node_manager == fnm ]]; then
+    $mise_active && die "fnm cannot be selected while Mise owns Node at $mise_node_path"
+    fnm_node=${fnm_node:-22}
+    "$gum" confirm --default=false "Use fnm Node $fnm_node instead of Mise?" || die "fnm confirmation cancelled"
+  fi
+
+  if ! choice=$("$gum" choose --header 'Apply selected configuration?' --selected yes yes no); then
+    die "configuration selection cancelled"
+  fi
+  [[ $choice == yes || $choice == no ]] || die "invalid Gum config selection"
+  config=$choice
+fi
+
+validate_csv "$components_csv" components zsh yazi
+validate_csv "$optional_csv" optional-tools shellcheck git-lfs glow viu act pandoc-cli
+if [[ $node_manager == fnm && -z $fnm_node ]]; then
+  die "fnm selection requires --fnm-node"
+fi
+
+if [[ $node_manager == fnm && $mise_active == true ]]; then
+  die "fnm is mutually exclusive with active Mise Node at $mise_node_path; separately back up Mise config, run mise unuse --global node@VERSION --no-prune after approval, open a fresh shell, verify mise where node fails, then rerun"
+fi
+if [[ $node_manager == mise && $fnm_present == true ]]; then
+  die "Mise Node and fnm cannot be coinstalled; remove the existing fnm choice separately before rerunning"
+fi
+
+declare -A selected=()
+if [[ $components_csv != none ]]; then
+  IFS=, read -r -a values <<< "$components_csv"
+  for value in "${values[@]}"; do
+    [[ $value == zsh ]] && selected[omarchy-zsh]=true
+    [[ $value == yazi ]] && selected[yazi]=true
+  done
+fi
+if [[ $optional_csv != none ]]; then
+  IFS=, read -r -a values <<< "$optional_csv"
+  for value in "${values[@]}"; do selected[$value]=true; done
+fi
+[[ $node_manager == fnm ]] && selected[fnm]=true
+base_owned=()
+already_present=()
+queued=()
+
+for package in "${catalog[@]}"; do
+  [[ ${selected[$package]:-false} == true ]] || continue
+  if base_owns "$package"; then
+    omarchy pkg present "$package" >/dev/null 2>&1 ||
+      die "$package is Omarchy base-owned but missing; repair Omarchy instead"
+    base_owned+=("$package")
+  elif omarchy pkg present "$package" >/dev/null 2>&1; then
+    already_present+=("$package")
+  else
+    queued+=("$package")
+  fi
+done
+
+fnm_install_command=()
+fnm_default_command=()
+if [[ $node_manager == mise ]]; then
+  if $mise_active; then
+    node_plan="preserve Mise Node: $mise_node_path"
+    node_command=()
+  else
+    node_plan='install Mise Node with: omarchy install dev-env node'
+    node_command=(omarchy install dev-env node)
+  fi
+else
+  node_plan="install if absent: fnm install $fnm_node; set default if different: fnm default $fnm_node"
+  node_command=()
+  fnm_install_command=(fnm install "$fnm_node")
+  fnm_default_command=(fnm default "$fnm_node")
+fi
+
+zsh_enabled=false
+yazi_enabled=false
+[[ ,$components_csv, == *,zsh,* ]] && zsh_enabled=true
+[[ ,$components_csv, == *,yazi,* ]] && yazi_enabled=true
+ansible_command=(ansible-playbook "$repo/setup.yml" --tags omarchy_config \
+  -e "backup_dir=$backup_dir" -e "omarchy_zsh_enabled=$zsh_enabled" \
+  -e "omarchy_yazi_enabled=$yazi_enabled")
+
+join_or_none() {
+  if (($#)); then
+    printf '%s' "$*"
+  else
+    printf '%s' none
+  fi
+}
+print_command() { printf '%q ' "$@"; printf '\n'; }
+printf 'Target: %s\n' "$omarchy_path"
+printf 'Base manifest: %s\n' "$base_manifest"
+printf 'components: %s\n' "$components_csv"
+printf 'optional-tools: %s\n' "$optional_csv"
+printf 'node-manager: %s\n' "$node_manager"
+printf 'Mise Node: %s\n' "$mise_node_path"
+printf 'base-owned: %s\n' "$(join_or_none "${base_owned[@]}")"
+printf 'already-present: %s\n' "$(join_or_none "${already_present[@]}")"
+printf 'package-add: %s\n' "$(join_or_none "${queued[@]}")"
+printf 'Node action: %s\n' "$node_plan"
+printf 'config: %s (zsh=%s yazi=%s)\n' "$config" "$zsh_enabled" "$yazi_enabled"
+printf 'receipt: %s\n' "$receipt"
+if [[ $config == yes ]]; then
+  printf 'Ansible command: '
+  if $dry_run; then
+    print_command "${ansible_command[@]}" --check --diff
+  else
+    print_command "${ansible_command[@]}"
+  fi
+else
+  printf 'Ansible command: none\n'
+fi
+printf 'Rollback: restore only the five documented config paths; package/Node rollback is not provided.\n'
+
+write_receipt_header() {
+  printf 'repository-head: %s\n' "$(git -C "$repo" rev-parse HEAD)"
+  printf 'date: %s\n' "$(date -Iseconds)"
+  printf 'components: %s\n' "$components_csv"
+  printf 'optional-tools: %s\n' "$optional_csv"
+  printf 'base-owned: %s\n' "$(join_or_none "${base_owned[@]}")"
+  printf 'already-present: %s\n' "$(join_or_none "${already_present[@]}")"
+  printf 'queued: %s\n' "$(join_or_none "${queued[@]}")"
+  printf 'node-manager: %s\n' "$node_manager"
+  printf 'detected-mise-node: %s\n' "$mise_node_path"
+  printf 'node-plan: %s\n' "$node_plan"
+  printf 'ansible: tag=omarchy_config zsh=%s yazi=%s\n' "$zsh_enabled" "$yazi_enabled"
+}
+
+if $dry_run; then
+  printf '%s\n' '--- dry-run receipt (not written) ---'
+  write_receipt_header
+  if ((${#queued[@]})); then
+    printf 'command: '; print_command omarchy pkg add "${queued[@]}"; printf 'status: not-run\n'
+  fi
+  if ((${#node_command[@]})); then
+    printf 'command: '; print_command "${node_command[@]}"; printf 'status: not-run\n'
+  fi
+  if [[ $node_manager == fnm ]]; then
+    printf 'command (if absent): '; print_command "${fnm_install_command[@]}"; printf 'status: not-run\n'
+    printf 'command (if default differs): '; print_command "${fnm_default_command[@]}"; printf 'status: not-run\n'
+  fi
+  if [[ $config == yes ]]; then
+    printf 'command: '; print_command "${ansible_command[@]}" --check --diff; printf 'status: not-run\n'
+  fi
+  exit 0
+fi
+
+if ! $non_interactive; then
+  "$gum" confirm --default=false 'Apply this plan?' || die "final confirmation cancelled"
+fi
+
+mkdir -p "$backup_dir"
+write_receipt_header > "$receipt"
+run_recorded() {
+  printf 'command:' >> "$receipt"
+  printf ' %q' "$@" >> "$receipt"
+  printf '\n' >> "$receipt"
+  set +e
+  "$@"
+  status=$?
+  set -e
+  printf 'status: %s\n' "$status" >> "$receipt"
+  return "$status"
+}
+
+if ((${#queued[@]})); then
+  run_recorded omarchy pkg add "${queued[@]}" || die "package installation failed; see $receipt"
+fi
+
+if [[ $node_manager == mise && ${#node_command[@]} -gt 0 ]]; then
+  run_recorded "${node_command[@]}" || die "Mise Node installation failed; see $receipt"
+elif [[ $node_manager == fnm ]]; then
+  command -v fnm >/dev/null || die "fnm package installed but command is unavailable"
+  escaped_fnm_node=${fnm_node//./\\.}
+  fnm_version_pattern="(^|[[:space:]*])v?${escaped_fnm_node}([.][0-9]+)*([[:space:]]|$)"
+  if ! fnm ls 2>/dev/null | grep -Eq "$fnm_version_pattern"; then
+    run_recorded fnm install "$fnm_node" || die "fnm Node installation failed; see $receipt"
+  fi
+  current_default=$(fnm default 2>/dev/null || true)
+  if ! grep -Eq "$fnm_version_pattern" <<< "$current_default"; then
+    run_recorded fnm default "$fnm_node" || die "fnm default selection failed; see $receipt"
+  fi
+fi
+
+if [[ $config == yes ]]; then
+  run_recorded "${ansible_command[@]}" || die "configuration failed; see $receipt"
+fi
+printf 'Install complete. Receipt: %s\n' "$receipt"

--- a/omarchy/zsh/.zprofile
+++ b/omarchy/zsh/.zprofile
@@ -1,0 +1,11 @@
+# Omarchy login environment without Homebrew or a node-version manager.
+omarchy_root=${OMARCHY_PATH:-/usr/share/omarchy}
+[[ -r "$omarchy_root/default/bash/env-bootstrap" ]] &&
+  source "$omarchy_root/default/bash/env-bootstrap"
+
+typeset -U path PATH
+export PNPM_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/pnpm"
+export PATH="$PNPM_HOME:$HOME/.local/bin:$PATH"
+export EDITOR="nvim"
+
+[[ -r "$HOME/.secrets" ]] && source "$HOME/.secrets"

--- a/omarchy/zsh/.zshrc
+++ b/omarchy/zsh/.zshrc
@@ -1,0 +1,17 @@
+# Official Omarchy environment and shell integration first; personal additions last.
+[[ -o interactive ]] || return
+
+omarchy_root=${OMARCHY_PATH:-/usr/share/omarchy}
+omarchy_zsh_root=${OMARCHY_ZSH_PATH:-/usr/share/omarchy-zsh}
+
+[[ -r "$omarchy_root/default/bash/env-bootstrap" ]] &&
+  source "$omarchy_root/default/bash/env-bootstrap"
+
+export STARSHIP_CONFIG="$HOME/.config/dotfiles/starship.toml"
+
+[[ -r "$omarchy_zsh_root/shell/zoptions" ]] &&
+  source "$omarchy_zsh_root/shell/zoptions"
+[[ -r "$omarchy_zsh_root/shell/all" ]] &&
+  source "$omarchy_zsh_root/shell/all"
+[[ -r "$HOME/.config/dotfiles/zsh/personal.zsh" ]] &&
+  source "$HOME/.config/dotfiles/zsh/personal.zsh"

--- a/omarchy/zsh/personal.zsh
+++ b/omarchy/zsh/personal.zsh
@@ -9,6 +9,10 @@ fi
 (( $+commands[nvim] )) && alias vim='nvim'
 (( $+commands[lazygit] )) && alias lg='lazygit'
 
+if (( $+commands[fnm] )) && ! mise where node >/dev/null 2>&1; then
+  eval "$(fnm env --use-on-cd --shell zsh)"
+fi
+
 if (( $+commands[yazi] )); then
   y() {
     local tmp cwd

--- a/omarchy/zsh/personal.zsh
+++ b/omarchy/zsh/personal.zsh
@@ -1,0 +1,21 @@
+# Personal additions loaded after the official Omarchy Zsh integration.
+alias ':q'='exit'
+alias reload='exec zsh'
+
+if (( $+commands[eza] )); then
+  alias l='eza -l -b --all --header --git --icons --group-directories-first'
+  alias ls='eza -l -b --all --header --git --icons --group-directories-first'
+fi
+(( $+commands[nvim] )) && alias vim='nvim'
+(( $+commands[lazygit] )) && alias lg='lazygit'
+
+if (( $+commands[yazi] )); then
+  y() {
+    local tmp cwd
+    tmp=$(mktemp -t yazi-cwd.XXXXXX) || return
+    command yazi "$@" --cwd-file="$tmp"
+    cwd=$(<"$tmp")
+    rm -f -- "$tmp"
+    [[ -n $cwd && $cwd != "$PWD" && -d $cwd ]] && builtin cd -- "$cwd"
+  }
+fi

--- a/setup.yml
+++ b/setup.yml
@@ -9,12 +9,13 @@
   connection: local
   vars_files:
     - brew_packages.yml # -> formulae (dict), casks (list)
-    - "vars/{{ ansible_os_family }}.yml" # Darwin.yml / Debian.yml, loaded after facts
   vars:
     home: "{{ ansible_env.HOME }}" # not `~`: become tasks would expand it to /root
     dotfiles: "{{ playbook_dir }}"
     backup_dir: "{{ home }}/.dotfiles_backup/{{ ansible_date_time.iso8601_basic_short }}"
     node_version: "22"
+    is_omarchy: "{{ (ansible_distribution | lower) == 'omarchy' }}"
+    is_legacy_platform: "{{ ansible_os_family in ['Darwin', 'Debian'] and not is_omarchy }}"
     # For the tasks that call brew/fnm/tmux: on PATH now, not just at next login.
     tool_env:
       PATH: "{{ brew_prefix }}/bin:{{ home }}/.local/bin:{{ ansible_env.PATH }}"
@@ -40,10 +41,27 @@
       - { src: codex/AGENTS.md, dest: .codex/AGENTS.md }
       - { src: codex/instructions.md, dest: .codex/instructions.md }
       - { src: codex/rules, dest: .codex/rules }
+  pre_tasks:
+    - name: Require a supported platform
+      ansible.builtin.assert:
+        that: is_omarchy or ansible_os_family in ['Darwin', 'Debian']
+        fail_msg: Only macOS, Debian-family Linux, and Omarchy are supported
+        quiet: true
+      tags: always
+
+    - name: Load platform variables
+      ansible.builtin.include_vars: "vars/{{ 'Omarchy' if is_omarchy else ansible_os_family }}.yml"
+      tags: always
+
   tasks:
+    - name: Omarchy adapter
+      ansible.builtin.import_tasks: tasks/omarchy.yml
+      when: is_omarchy
+      tags: [omarchy, never]
+
     - name: Debian/Ubuntu packages
       ansible.builtin.import_tasks: tasks/debian.yml
-      when: ansible_os_family == 'Debian'
+      when: ansible_os_family == 'Debian' and not is_omarchy
       tags: packages
 
     - name: Homebrew formulae
@@ -51,6 +69,7 @@
         name: "{{ brew_formulae | reject('search', '/') }}"
         state: present
       environment: "{{ tool_env }}"
+      when: is_legacy_platform
       tags: packages
 
     # Tap-qualified names (cirruslabs/cli/tart) bypass the module: it fails on any stderr from
@@ -66,6 +85,7 @@
         creates: "{{ brew_prefix }}/bin/{{ item | basename }}"
       loop: "{{ brew_formulae | select('search', '/') }}"
       environment: "{{ tool_env }}"
+      when: is_legacy_platform
       tags: packages
 
     - name: Homebrew casks
@@ -73,7 +93,7 @@
         name: "{{ casks }}"
         state: present
       environment: "{{ tool_env }}"
-      when: ansible_os_family == 'Darwin'
+      when: is_legacy_platform and ansible_os_family == 'Darwin'
       tags: packages
 
     # fnm picks its data dir itself (legacy ~/.fnm, XDG_DATA_HOME, per-OS default), so ask it
@@ -92,6 +112,7 @@
       register: node
       changed_when: "'installed' in node.stdout"
       environment: "{{ tool_env }}"
+      when: is_legacy_platform
       tags: packages
 
     # Families live in subdirectories next to licences and READMEs, so recurse
@@ -102,6 +123,7 @@
         patterns: ["*.ttf", "*.otf", "*.ttc"]
         recurse: true
       register: font_faces
+      when: is_legacy_platform
       tags: fonts
 
     # copy does not create parent dirs. No mode: ~/Library/Fonts pre-exists as 0700.
@@ -109,6 +131,7 @@
       ansible.builtin.file:
         path: "{{ fonts_dir }}"
         state: directory
+      when: is_legacy_platform
       tags: fonts
 
     # Copied, not linked: macOS CoreText is unreliable about symlinked faces in ~/Library/Fonts.
@@ -117,15 +140,16 @@
         src: "{{ item }}"
         dest: "{{ fonts_dir }}/{{ item | basename }}"
         mode: "0644"
-      loop: "{{ font_faces.files | map(attribute='path') | sort }}"
+      loop: "{{ (font_faces.files | default([])) | map(attribute='path') | sort }}"
       loop_control:
         label: "{{ item | basename }}"
       register: fonts
+      when: is_legacy_platform
       tags: fonts
 
     - name: Font cache (macOS picks up ~/Library/Fonts on its own)
       ansible.builtin.command: fc-cache -f {{ fonts_dir }}
-      when: ansible_os_family == 'Debian' and fonts.changed
+      when: is_legacy_platform and ansible_os_family == 'Debian' and (fonts.changed | default(false))
       changed_when: true
       tags: fonts
 
@@ -135,6 +159,7 @@
         dest: "{{ home }}/.tmux/plugins/tpm"
         version: master
         update: false
+      when: is_legacy_platform
       tags: tmux
 
     - name: Secrets file (~/.secrets, create-if-absent, sourced by .zprofile)
@@ -154,6 +179,7 @@
           export BRAVE_API_KEY="your-api-key-here"
 
           # Add other secrets below as needed
+      when: is_legacy_platform
       tags: secrets
 
     # copy force:false never touches an existing file, so a pre-existing
@@ -162,12 +188,14 @@
       ansible.builtin.file:
         path: "{{ home }}/.secrets"
         mode: "0600"
+      when: is_legacy_platform
       tags: secrets
 
     - name: Symlinks
       ansible.builtin.import_tasks: tasks/symlinks.yml
       vars:
         links: "{{ dotfile_links }}"
+      when: is_legacy_platform
       tags: symlinks
 
     # Copy-if-absent: codex appends project trust entries at runtime, so this must not be a link.
@@ -177,6 +205,7 @@
         dest: "{{ home }}/.codex/config.toml"
         mode: "0644"
         force: false
+      when: is_legacy_platform
       tags: symlinks
 
     # tpm's installer shells out to tmux, so a configs-only run (--skip-tags
@@ -188,6 +217,7 @@
       register: tpm
       changed_when: "'download success' in tpm.stdout"
       environment: "{{ tool_env }}"
+      when: is_legacy_platform
       tags: tmux
 
     # A launcher and global hotkeys only mean anything in a graphical session. Never
@@ -196,5 +226,5 @@
     # over SSH should fail loudly, not skip every task and report success.)
     - name: Linux desktop
       ansible.builtin.import_tasks: tasks/desktop.yml
-      when: ansible_os_family == 'Debian'
+      when: ansible_os_family == 'Debian' and not is_omarchy
       tags: [desktop, never]

--- a/setup.yml
+++ b/setup.yml
@@ -1,5 +1,6 @@
 ---
-# Dotfiles setup. First time: ./bootstrap.sh (installs Ansible, then runs this).
+# Dotfiles setup. bootstrap.sh runs this on macOS/Debian; Omarchy calls the
+# explicit config-only adapter from install-omarchy.sh.
 #   ansible-playbook setup.yml -K      # Linux — apt/usermod need sudo
 #   ansible-playbook setup.yml         # macOS
 # Tags:  --skip-tags packages | --tags desktop | --tags symlinks,fonts,tmux,secrets | --skip-tags ollama
@@ -54,10 +55,10 @@
       tags: always
 
   tasks:
-    - name: Omarchy adapter
+    - name: Omarchy config adapter
       ansible.builtin.import_tasks: tasks/omarchy.yml
       when: is_omarchy
-      tags: [omarchy, never]
+      tags: [omarchy_config, never]
 
     - name: Debian/Ubuntu packages
       ansible.builtin.import_tasks: tasks/debian.yml

--- a/tasks/desktop.yml
+++ b/tasks/desktop.yml
@@ -4,6 +4,14 @@
 # Only reached via --tags desktop (see setup.yml). Failing loudly beats the
 # alternative — every task silently skipping on an SSH run that asked for
 # desktop by name.
+- name: Debian desktop boundary
+  ansible.builtin.assert:
+    that:
+      - ansible_os_family == 'Debian'
+      - not is_omarchy
+    fail_msg: Desktop tasks are only supported on non-Omarchy Debian-family systems
+    quiet: true
+
 - name: Graphical session required
   ansible.builtin.assert:
     that: ansible_env.XDG_CURRENT_DESKTOP is defined

--- a/tasks/omarchy.yml
+++ b/tasks/omarchy.yml
@@ -3,13 +3,13 @@
   ansible.builtin.stat:
     path: "{{ omarchy_path }}/default/hypr/bootstrap.lua"
   register: omarchy_bootstrap
-  tags: [omarchy_packages, omarchy_config, never]
+  tags: [omarchy_config, never]
 
 - name: Inspect Omarchy command
   ansible.builtin.stat:
     path: "{{ omarchy_command | default('/usr/bin/omarchy') }}"
   register: omarchy_command_stat
-  tags: [omarchy_packages, omarchy_config, never]
+  tags: [omarchy_config, never]
 
 - name: Require a real Omarchy installation
   ansible.builtin.assert:
@@ -19,31 +19,7 @@
       - omarchy_command_stat.stat.exists
     fail_msg: Omarchy adapter requires Omarchy markers and its public command
     quiet: true
-  tags: [omarchy_packages, omarchy_config, never]
-
-- name: Probe Omarchy packages
-  ansible.builtin.command:
-    argv: ["{{ omarchy_command | default('/usr/bin/omarchy') }}", "pkg", "present", "{{ item }}"]
-  loop: "{{ omarchy_packages }}"
-  register: omarchy_package_probe
-  changed_when: false
-  failed_when: false
-  check_mode: false
-  tags: [omarchy_packages, never]
-
-- name: Add missing Omarchy packages
-  ansible.builtin.command:
-    argv: "{{ [omarchy_command | default('/usr/bin/omarchy'), 'pkg', 'add'] + omarchy_missing_packages }}"
-  vars:
-    omarchy_missing_packages: >-
-      {{ omarchy_package_probe.results
-         | rejectattr('rc', 'equalto', 0)
-         | map(attribute='item')
-         | list }}
-  become: "{{ omarchy_become | default(true) }}"
-  when: omarchy_missing_packages | length > 0
-  changed_when: true
-  tags: [omarchy_packages, never]
+  tags: [omarchy_config, never]
 
 - name: Back up changed Omarchy Zsh entry files # noqa: command-instead-of-shell
   ansible.builtin.shell: |
@@ -61,7 +37,7 @@
     - { src: omarchy/zsh/.zprofile, dest: .zprofile }
   register: omarchy_zsh_backup
   changed_when: "'backed-up' in omarchy_zsh_backup.stdout"
-  when: omarchy_zsh_enabled
+  when: omarchy_zsh_enabled | bool
   tags: [omarchy_config, never]
 
 - name: Copy Omarchy Zsh entry files
@@ -72,7 +48,7 @@
   loop:
     - { src: omarchy/zsh/.zshrc, dest: .zshrc }
     - { src: omarchy/zsh/.zprofile, dest: .zprofile }
-  when: omarchy_zsh_enabled
+  when: omarchy_zsh_enabled | bool
   tags: [omarchy_config, never]
 
 - name: Link Omarchy extensions

--- a/tasks/omarchy.yml
+++ b/tasks/omarchy.yml
@@ -1,0 +1,82 @@
+---
+- name: Inspect Omarchy bootstrap marker
+  ansible.builtin.stat:
+    path: "{{ omarchy_path }}/default/hypr/bootstrap.lua"
+  register: omarchy_bootstrap
+  tags: [omarchy_packages, omarchy_config, never]
+
+- name: Inspect Omarchy command
+  ansible.builtin.stat:
+    path: "{{ omarchy_command | default('/usr/bin/omarchy') }}"
+  register: omarchy_command_stat
+  tags: [omarchy_packages, omarchy_config, never]
+
+- name: Require a real Omarchy installation
+  ansible.builtin.assert:
+    that:
+      - ansible_distribution | lower == 'omarchy'
+      - omarchy_bootstrap.stat.exists
+      - omarchy_command_stat.stat.exists
+    fail_msg: Omarchy adapter requires Omarchy markers and its public command
+    quiet: true
+  tags: [omarchy_packages, omarchy_config, never]
+
+- name: Probe Omarchy packages
+  ansible.builtin.command:
+    argv: ["{{ omarchy_command | default('/usr/bin/omarchy') }}", "pkg", "present", "{{ item }}"]
+  loop: "{{ omarchy_packages }}"
+  register: omarchy_package_probe
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  tags: [omarchy_packages, never]
+
+- name: Add missing Omarchy packages
+  ansible.builtin.command:
+    argv: "{{ [omarchy_command | default('/usr/bin/omarchy'), 'pkg', 'add'] + omarchy_missing_packages }}"
+  vars:
+    omarchy_missing_packages: >-
+      {{ omarchy_package_probe.results
+         | rejectattr('rc', 'equalto', 0)
+         | map(attribute='item')
+         | list }}
+  become: "{{ omarchy_become | default(true) }}"
+  when: omarchy_missing_packages | length > 0
+  changed_when: true
+  tags: [omarchy_packages, never]
+
+- name: Back up changed Omarchy Zsh entry files # noqa: command-instead-of-shell
+  ansible.builtin.shell: |
+    target={{ (home ~ '/' ~ item.dest) | quote }}
+    source={{ (dotfiles ~ '/' ~ item.src) | quote }}
+    if { [ -e "$target" ] || [ -L "$target" ]; } && ! cmp -s "$source" "$target"; then
+      mkdir -p {{ backup_dir | quote }}
+      mv "$target" {{ (backup_dir ~ '/' ~ item.dest | replace('/', '_') ~ '.bak') | quote }}
+      echo backed-up
+    fi
+  args:
+    executable: /bin/bash
+  loop:
+    - { src: omarchy/zsh/.zshrc, dest: .zshrc }
+    - { src: omarchy/zsh/.zprofile, dest: .zprofile }
+  register: omarchy_zsh_backup
+  changed_when: "'backed-up' in omarchy_zsh_backup.stdout"
+  when: omarchy_zsh_enabled
+  tags: [omarchy_config, never]
+
+- name: Copy Omarchy Zsh entry files
+  ansible.builtin.copy:
+    src: "{{ dotfiles }}/{{ item.src }}"
+    dest: "{{ home }}/{{ item.dest }}"
+    mode: "0644"
+  loop:
+    - { src: omarchy/zsh/.zshrc, dest: .zshrc }
+    - { src: omarchy/zsh/.zprofile, dest: .zprofile }
+  when: omarchy_zsh_enabled
+  tags: [omarchy_config, never]
+
+- name: Link Omarchy extensions
+  ansible.builtin.import_tasks: symlinks.yml
+  vars:
+    links: "{{ omarchy_links | selectattr('enabled') | list }}"
+  tags: [omarchy_config, never]

--- a/tests/fixtures/omarchy-zsh/shell/all
+++ b/tests/fixtures/omarchy-zsh/shell/all
@@ -1,0 +1,1 @@
+# Fake omarchy-zsh main loader for disposable-HOME tests.

--- a/tests/fixtures/omarchy-zsh/shell/zoptions
+++ b/tests/fixtures/omarchy-zsh/shell/zoptions
@@ -1,0 +1,1 @@
+# Fake omarchy-zsh options loader for disposable-HOME tests.

--- a/tests/fixtures/omarchy/bin/ansible-galaxy
+++ b/tests/fixtures/omarchy/bin/ansible-galaxy
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+[[ ${1-} == collection && ${2-} == list && ${3-} == community.general ]] && {
+  printf '%s\n' 'community.general 1.0.0'
+  exit 0
+}
+[[ ${1-} == collection && ${2-} == install ]] && exit 0
+exit 64

--- a/tests/fixtures/omarchy/bin/ansible-playbook.mock
+++ b/tests/fixtures/omarchy/bin/ansible-playbook.mock
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+root=${DOTFILES_MOCK_ROOT:?}
+printf 'ansible-playbook' >> "$root/ansible-calls"
+for arg in "$@"; do printf ' %s' "$arg" >> "$root/ansible-calls"; done
+printf '\n' >> "$root/ansible-calls"

--- a/tests/fixtures/omarchy/bin/fnm.mock
+++ b/tests/fixtures/omarchy/bin/fnm.mock
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+root=${DOTFILES_MOCK_ROOT:?}
+case ${1-} in
+  ls|list)
+    if [[ -f $root/fnm-nodes ]]; then
+      awk '{ print "v" $0 }' "$root/fnm-nodes"
+    fi
+    ;;
+  install)
+    [[ $# -eq 2 ]] || exit 64
+    printf 'fnm install %s\n' "$2" >> "$root/calls"
+    grep -Fxq -- "$2" "$root/fnm-nodes" 2>/dev/null || printf '%s\n' "$2" >> "$root/fnm-nodes"
+    ;;
+  default)
+    if [[ $# -eq 1 ]]; then
+      if [[ -s $root/fnm-default ]]; then
+        read -r value < "$root/fnm-default"
+        printf '%s\n' "$value"
+      fi
+    elif [[ $# -eq 2 ]]; then
+      printf 'fnm default %s\n' "$2" >> "$root/calls"
+      printf '%s\n' "$2" > "$root/fnm-default"
+    else
+      exit 64
+    fi
+    ;;
+  *) exit 64 ;;
+esac

--- a/tests/fixtures/omarchy/bin/gum
+++ b/tests/fixtures/omarchy/bin/gum
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+root=${DOTFILES_MOCK_ROOT:?}
+printf 'gum' >> "$root/gum-calls"
+for arg in "$@"; do printf ' %s' "$arg" >> "$root/gum-calls"; done
+printf '\n' >> "$root/gum-calls"
+mapfile -t responses < "$root/gum-responses"
+((${#responses[@]})) || exit 1
+response=${responses[0]}
+printf '%s\n' "${responses[@]:1}" > "$root/gum-responses"
+[[ $response != __CANCEL__ ]] || exit 1
+case ${1-} in
+  choose)
+    multi=false
+    for arg in "$@"; do [[ $arg == --no-limit ]] && multi=true; done
+    if $multi; then
+      tr ';' '\n' <<< "$response"
+    else
+      printf '%s\n' "$response"
+    fi
+    ;;
+  confirm) [[ $response == yes ]] ;;
+  *) exit 64 ;;
+esac

--- a/tests/fixtures/omarchy/bin/mise
+++ b/tests/fixtures/omarchy/bin/mise
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+root=${DOTFILES_MOCK_ROOT:?}
+case ${1-} in
+  where)
+    [[ ${2-} == node && $# -eq 2 ]] || exit 64
+    [[ -s $root/mise-node ]] || exit 1
+    read -r node_path < "$root/mise-node"
+    printf '%s\n' "$node_path"
+    ;;
+  *) exit 64 ;;
+esac

--- a/tests/fixtures/omarchy/bin/omarchy
+++ b/tests/fixtures/omarchy/bin/omarchy
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+state="$root/present"
+calls="$root/calls"
+
+[[ ${1-} == pkg ]] || exit 64
+case ${2-} in
+  present)
+    [[ $# -eq 3 ]] || exit 64
+    grep -Fxq -- "$3" "$state" 2>/dev/null
+    ;;
+  add)
+    shift 2
+    [[ $# -gt 0 ]] || exit 64
+    printf 'add' >> "$calls"
+    for package in "$@"; do
+      printf ' %s' "$package" >> "$calls"
+      grep -Fxq -- "$package" "$state" 2>/dev/null || printf '%s\n' "$package" >> "$state"
+    done
+    printf '\n' >> "$calls"
+    ;;
+  *) exit 64 ;;
+esac

--- a/tests/fixtures/omarchy/bin/omarchy
+++ b/tests/fixtures/omarchy/bin/omarchy
@@ -1,25 +1,41 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-root=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+root=${DOTFILES_MOCK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}
 state="$root/present"
 calls="$root/calls"
+printf '%s' "$1" >> "$calls"
+for arg in "${@:2}"; do printf ' %s' "$arg" >> "$calls"; done
+printf '\n' >> "$calls"
 
-[[ ${1-} == pkg ]] || exit 64
-case ${2-} in
-  present)
-    [[ $# -eq 3 ]] || exit 64
-    grep -Fxq -- "$3" "$state" 2>/dev/null
+case ${1-} in
+  pkg)
+    case ${2-} in
+      present)
+        [[ $# -eq 3 ]] || exit 64
+        grep -Fxq -- "$3" "$state" 2>/dev/null
+        ;;
+      add)
+        shift 2
+        [[ $# -gt 0 ]] || exit 64
+        [[ ! -e $root/fail-add ]] || exit 17
+        for package in "$@"; do
+          grep -Fxq -- "$package" "$state" 2>/dev/null || printf '%s\n' "$package" >> "$state"
+          if [[ $package == ansible && -f $root/bin/.ansible-playbook.mock ]]; then
+            cp "$root/bin/.ansible-playbook.mock" "$root/bin/ansible-playbook"
+            chmod +x "$root/bin/ansible-playbook"
+          elif [[ $package == fnm && -f $root/bin/.fnm.mock ]]; then
+            cp "$root/bin/.fnm.mock" "$root/bin/fnm"
+            chmod +x "$root/bin/fnm"
+          fi
+        done
+        ;;
+      *) exit 64 ;;
+    esac
     ;;
-  add)
-    shift 2
-    [[ $# -gt 0 ]] || exit 64
-    printf 'add' >> "$calls"
-    for package in "$@"; do
-      printf ' %s' "$package" >> "$calls"
-      grep -Fxq -- "$package" "$state" 2>/dev/null || printf '%s\n' "$package" >> "$state"
-    done
-    printf '\n' >> "$calls"
+  install)
+    [[ ${2-} == dev-env && ${3-} == node && $# -eq 3 ]] || exit 64
+    printf '%s\n' '/mock/mise/installs/node/26.8.1' > "$root/mise-node"
     ;;
   *) exit 64 ;;
 esac

--- a/tests/fixtures/omarchy/default/bash/env-bootstrap
+++ b/tests/fixtures/omarchy/default/bash/env-bootstrap
@@ -1,0 +1,1 @@
+# Fake environment loader for disposable-HOME tests.

--- a/tests/fixtures/omarchy/default/hypr/bootstrap.lua
+++ b/tests/fixtures/omarchy/default/hypr/bootstrap.lua
@@ -1,0 +1,1 @@
+-- Fake Omarchy bootstrap marker for disposable-HOME tests.

--- a/tests/omarchy-boundaries.sh
+++ b/tests/omarchy-boundaries.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+require_file() { [[ -f "$repo/$1" ]] || fail "missing $1"; }
+require_text() {
+  local file=$1 text=$2
+  grep -Fq -- "$text" "$repo/$file" || fail "$file missing: $text"
+}
+
+for file in vars/Omarchy.yml tasks/omarchy.yml omarchy/zsh/.zshrc \
+  omarchy/zsh/.zprofile omarchy/zsh/personal.zsh tests/omarchy-integration.sh; do
+  require_file "$file"
+done
+
+if grep -ERiq --include='*.yml' \
+  'pacman[[:space:]]+-S(yu|yyu)|(^|[^[:alnum:]_-])(yay|paru)([^[:alnum:]_-]|$)|omarchy[[:space:]]+update|omarchy-setup-zsh|(^|[^[:alnum:]_-])chsh([^[:alnum:]_-]|$)|hyprctl[[:space:]]+reload' \
+  "$repo/setup.yml" "$repo/tasks" "$repo/vars/Omarchy.yml"; then
+  fail 'prohibited package/update/activation command in repository task code'
+fi
+
+mapfile -t packages < <(
+  awk '
+    /^omarchy_packages:/ { in_packages=1; next }
+    in_packages && /^  - / { sub(/^  - /, ""); print; next }
+    in_packages { exit }
+  ' "$repo/vars/Omarchy.yml"
+)
+[[ ${#packages[@]} -eq 2 ]] || fail 'Omarchy package allowlist must contain exactly two entries'
+[[ ${packages[0]} == omarchy-zsh && ${packages[1]} == yazi ]] ||
+  fail 'Omarchy package allowlist must be exactly: omarchy-zsh yazi'
+
+mapfile -t managed_paths < <(awk '/^    dest: / { sub(/^    dest: /, ""); print }' "$repo/vars/Omarchy.yml")
+expected_paths=(
+  .config/dotfiles/zsh/personal.zsh
+  .config/dotfiles/starship.toml
+  .config/yazi
+)
+[[ ${managed_paths[*]} == "${expected_paths[*]}" ]] ||
+  fail 'Omarchy managed-path allowlist must contain only personal Zsh, unique Starship, and Yazi targets'
+
+for forbidden in \
+  'hypr/hyprland.lua' 'hypr/bindings.lua' 'omarchy/shell.json' \
+  'foot/foot.ini' 'ghostty/config' '.config/nvim' '.config/tmux' \
+  '.tmux.conf' '.config/atuin' '.config/sheldon' 'fonts/'; do
+  if grep -FRq -- "$forbidden" "$repo/vars/Omarchy.yml" "$repo/tasks/omarchy.yml" "$repo/omarchy"; then
+    fail "forbidden Omarchy-managed path: $forbidden"
+  fi
+done
+
+if awk '/^[[:space:]]+dest:/ && $0 !~ /{{ home }}\// { print; bad=1 } END { exit bad ? 0 : 1 }' \
+  "$repo/tasks/omarchy.yml" | grep -q .; then
+  fail 'every Omarchy task destination must begin with {{ home }}/'
+fi
+
+require_text setup.yml 'is_omarchy: "{{ (ansible_distribution | lower) == '\''omarchy'\'' }}"'
+require_text setup.yml "is_legacy_platform: \"{{ ansible_os_family in ['Darwin', 'Debian'] and not is_omarchy }}\""
+require_text setup.yml "vars/{{ 'Omarchy' if is_omarchy else ansible_os_family }}.yml"
+require_text setup.yml 'when: is_legacy_platform'
+require_text setup.yml "when: ansible_os_family == 'Debian' and not is_omarchy"
+require_text setup.yml 'tags: [omarchy, never]'
+require_text tasks/desktop.yml "ansible_os_family == 'Debian'"
+require_text tasks/desktop.yml 'not is_omarchy'
+
+require_text tasks/omarchy.yml '"pkg", "present"'
+grep -Eq "['\"]pkg['\"], ['\"]add['\"]" "$repo/tasks/omarchy.yml" ||
+  fail 'tasks/omarchy.yml missing public pkg add argv'
+require_text tasks/omarchy.yml 'become: "{{ omarchy_become | default(true) }}"'
+require_text tasks/omarchy.yml 'tags: [omarchy_packages, never]'
+require_text tasks/omarchy.yml 'tags: [omarchy_config, never]'
+
+zshrc="$repo/omarchy/zsh/.zshrc"
+# These searches intentionally match literal Zsh variable references.
+# shellcheck disable=SC2016
+zoptions_line=$(grep -nF 'source "$omarchy_zsh_root/shell/zoptions"' "$zshrc" | cut -d: -f1)
+# shellcheck disable=SC2016
+all_line=$(grep -nF 'source "$omarchy_zsh_root/shell/all"' "$zshrc" | cut -d: -f1)
+# shellcheck disable=SC2016
+personal_line=$(grep -nF 'source "$HOME/.config/dotfiles/zsh/personal.zsh"' "$zshrc" | cut -d: -f1)
+[[ -n $zoptions_line && -n $all_line && -n $personal_line ]] || fail 'incomplete Omarchy Zsh loader chain'
+(( zoptions_line < all_line && all_line < personal_line )) || fail 'personal Zsh code must load after both official loaders'
+# shellcheck disable=SC2016
+require_text omarchy/zsh/.zshrc 'export STARSHIP_CONFIG="$HOME/.config/dotfiles/starship.toml"'
+
+if grep -ERiq 'sheldon|atuin|starship init|zoxide init|fzf --zsh|fnm|mise' "$repo/omarchy/zsh/personal.zsh"; then
+  fail 'personal Omarchy overlay reinitializes an official/skipped shell tool'
+fi
+
+require_text .github/workflows/test-setup-ci.yml 'bash tests/omarchy-boundaries.sh'
+require_text .github/workflows/test-setup-ci.yml 'REQUIRE_ANSIBLE=1 bash tests/omarchy-integration.sh'
+require_text README.md '## Omarchy (opt-in)'
+require_text README.md 'ansible-playbook setup.yml -K --tags omarchy --check --diff'
+require_text README.md 'ansible-playbook setup.yml -K --tags omarchy'
+require_text README.md 'ansible-playbook setup.yml --tags omarchy_config'
+require_text README.md 'omarchy-setup-zsh'
+require_text README.md '### Omarchy rollback'
+
+printf 'Omarchy boundary checks passed\n'

--- a/tests/omarchy-boundaries.sh
+++ b/tests/omarchy-boundaries.sh
@@ -8,29 +8,60 @@ require_text() {
   local file=$1 text=$2
   grep -Fq -- "$text" "$repo/$file" || fail "$file missing: $text"
 }
+forbid_text() {
+  local file=$1 pattern=$2
+  ! grep -Eq -- "$pattern" "$repo/$file" || fail "$file contains prohibited pattern: $pattern"
+}
 
-for file in vars/Omarchy.yml tasks/omarchy.yml omarchy/zsh/.zshrc \
-  omarchy/zsh/.zprofile omarchy/zsh/personal.zsh tests/omarchy-integration.sh; do
+for file in bootstrap.sh install-omarchy.sh vars/Omarchy.yml tasks/omarchy.yml \
+  omarchy/zsh/.zshrc omarchy/zsh/.zprofile omarchy/zsh/personal.zsh \
+  tests/omarchy-integration.sh tests/omarchy-installer.sh; do
   require_file "$file"
 done
+[[ -x "$repo/install-omarchy.sh" ]] || fail 'install-omarchy.sh must be executable'
 
-if grep -ERiq --include='*.yml' \
-  'pacman[[:space:]]+-S(yu|yyu)|(^|[^[:alnum:]_-])(yay|paru)([^[:alnum:]_-]|$)|omarchy[[:space:]]+update|omarchy-setup-zsh|(^|[^[:alnum:]_-])chsh([^[:alnum:]_-]|$)|hyprctl[[:space:]]+reload' \
-  "$repo/setup.yml" "$repo/tasks" "$repo/vars/Omarchy.yml"; then
-  fail 'prohibited package/update/activation command in repository task code'
+# Ansible's Omarchy path is config-only and never-tagged.
+forbid_text vars/Omarchy.yml '^omarchy_packages:'
+forbid_text tasks/omarchy.yml 'pkg.*(present|add)|omarchy_packages|omarchy_package'
+forbid_text setup.yml 'omarchy_packages'
+require_text setup.yml 'Omarchy config adapter'
+require_text setup.yml 'tags: [omarchy_config, never]'
+forbid_text setup.yml 'tags: \[omarchy, never\]'
+require_text tasks/omarchy.yml 'tags: [omarchy_config, never]'
+require_text tasks/omarchy.yml 'when: omarchy_zsh_enabled | bool'
+require_text vars/Omarchy.yml 'enabled: "{{ omarchy_yazi_enabled | bool }}"'
+if grep -Fq 'omarchy_packages' "$repo/tasks/omarchy.yml" "$repo/vars/Omarchy.yml" "$repo/setup.yml"; then
+  fail 'Ansible still exposes the removed omarchy_packages interface'
 fi
 
-mapfile -t packages < <(
-  awk '
-    /^omarchy_packages:/ { in_packages=1; next }
-    in_packages && /^  - / { sub(/^  - /, ""); print; next }
-    in_packages { exit }
-  ' "$repo/vars/Omarchy.yml"
-)
-[[ ${#packages[@]} -eq 2 ]] || fail 'Omarchy package allowlist must contain exactly two entries'
-[[ ${packages[0]} == omarchy-zsh && ${packages[1]} == yazi ]] ||
-  fail 'Omarchy package allowlist must be exactly: omarchy-zsh yazi'
+# The installer's complete fixed catalog and public package route are explicit.
+require_text install-omarchy.sh 'catalog=(omarchy-zsh yazi shellcheck git-lfs glow viu act pandoc-cli fnm)'
+require_text install-omarchy.sh 'validate_csv "$components_csv" components zsh yazi'
+require_text install-omarchy.sh 'validate_csv "$optional_csv" optional-tools shellcheck git-lfs glow viu act pandoc-cli'
+require_text install-omarchy.sh 'run_recorded omarchy pkg add "${queued[@]}"'
+require_text install-omarchy.sh 'omarchy install dev-env node'
+require_text install-omarchy.sh 'omarchy-base.packages'
+require_text install-omarchy.sh 'omarchy-install.receipt'
+require_text install-omarchy.sh '--non-interactive'
+require_text install-omarchy.sh '--dry-run'
+require_text install-omarchy.sh '--backup-dir'
+require_text install-omarchy.sh "confirm --default=false 'Apply this plan?'"
 
+for file in bootstrap.sh install-omarchy.sh tasks/omarchy.yml vars/Omarchy.yml; do
+  forbid_text "$file" 'pkg[[:space:]]+aur|pacman[[:space:]]+-S|(^|[^[:alnum:]_-])(yay|paru)([^[:alnum:]_-]|$)|omarchy[[:space:]]+update|pkg[[:space:]]+(drop|remove)'
+done
+for deferred in aws aws-cli ollama ghostty hadolint k6 grpcurl ghz atuin sheldon; do
+  forbid_text install-omarchy.sh "(^|[^[:alnum:]_-])$deferred([^[:alnum:]_-]|$)"
+done
+forbid_text install-omarchy.sh 'arbitrary|passthrough|dev-env[[:space:]]+(python|go|rust|java)'
+
+# Bootstrap owns only the Omarchy Ansible prerequisite and never dispatches setup on that branch.
+require_text bootstrap.sh '[[ $os_id == omarchy ]]'
+require_text bootstrap.sh 'omarchy pkg add ansible'
+require_text bootstrap.sh 'Prerequisites ready. Next: ./install-omarchy.sh'
+require_text bootstrap.sh '(($# == 0))'
+
+# Managed HOME paths stay exactly within the original five-path contract.
 mapfile -t managed_paths < <(awk '/^    dest: / { sub(/^    dest: /, ""); print }' "$repo/vars/Omarchy.yml")
 expected_paths=(
   .config/dotfiles/zsh/personal.zsh
@@ -38,38 +69,28 @@ expected_paths=(
   .config/yazi
 )
 [[ ${managed_paths[*]} == "${expected_paths[*]}" ]] ||
-  fail 'Omarchy managed-path allowlist must contain only personal Zsh, unique Starship, and Yazi targets'
-
-for forbidden in \
-  'hypr/hyprland.lua' 'hypr/bindings.lua' 'omarchy/shell.json' \
-  'foot/foot.ini' 'ghostty/config' '.config/nvim' '.config/tmux' \
-  '.tmux.conf' '.config/atuin' '.config/sheldon' 'fonts/'; do
+  fail 'Omarchy managed-path allowlist changed'
+for forbidden in hypr/hyprland.lua hypr/bindings.lua omarchy/shell.json foot/foot.ini \
+  ghostty/config .config/nvim .config/tmux .tmux.conf .config/atuin .config/sheldon fonts/; do
   if grep -FRq -- "$forbidden" "$repo/vars/Omarchy.yml" "$repo/tasks/omarchy.yml" "$repo/omarchy"; then
     fail "forbidden Omarchy-managed path: $forbidden"
   fi
 done
-
 if awk '/^[[:space:]]+dest:/ && $0 !~ /{{ home }}\// { print; bad=1 } END { exit bad ? 0 : 1 }' \
   "$repo/tasks/omarchy.yml" | grep -q .; then
   fail 'every Omarchy task destination must begin with {{ home }}/'
 fi
 
+# Legacy platform gates and the defensive desktop assertion remain.
 require_text setup.yml 'is_omarchy: "{{ (ansible_distribution | lower) == '\''omarchy'\'' }}"'
 require_text setup.yml "is_legacy_platform: \"{{ ansible_os_family in ['Darwin', 'Debian'] and not is_omarchy }}\""
 require_text setup.yml "vars/{{ 'Omarchy' if is_omarchy else ansible_os_family }}.yml"
 require_text setup.yml 'when: is_legacy_platform'
 require_text setup.yml "when: ansible_os_family == 'Debian' and not is_omarchy"
-require_text setup.yml 'tags: [omarchy, never]'
 require_text tasks/desktop.yml "ansible_os_family == 'Debian'"
 require_text tasks/desktop.yml 'not is_omarchy'
 
-require_text tasks/omarchy.yml '"pkg", "present"'
-grep -Eq "['\"]pkg['\"], ['\"]add['\"]" "$repo/tasks/omarchy.yml" ||
-  fail 'tasks/omarchy.yml missing public pkg add argv'
-require_text tasks/omarchy.yml 'become: "{{ omarchy_become | default(true) }}"'
-require_text tasks/omarchy.yml 'tags: [omarchy_packages, never]'
-require_text tasks/omarchy.yml 'tags: [omarchy_config, never]'
-
+# Official loaders stay ahead of personal code and fnm is gated by inactive Mise Node.
 zshrc="$repo/omarchy/zsh/.zshrc"
 # These searches intentionally match literal Zsh variable references.
 # shellcheck disable=SC2016
@@ -79,21 +100,21 @@ all_line=$(grep -nF 'source "$omarchy_zsh_root/shell/all"' "$zshrc" | cut -d: -f
 # shellcheck disable=SC2016
 personal_line=$(grep -nF 'source "$HOME/.config/dotfiles/zsh/personal.zsh"' "$zshrc" | cut -d: -f1)
 [[ -n $zoptions_line && -n $all_line && -n $personal_line ]] || fail 'incomplete Omarchy Zsh loader chain'
-(( zoptions_line < all_line && all_line < personal_line )) || fail 'personal Zsh code must load after both official loaders'
+(( zoptions_line < all_line && all_line < personal_line )) || fail 'personal code loads before official loaders'
 # shellcheck disable=SC2016
 require_text omarchy/zsh/.zshrc 'export STARSHIP_CONFIG="$HOME/.config/dotfiles/starship.toml"'
+require_text omarchy/zsh/personal.zsh 'if (( $+commands[fnm] )) && ! mise where node >/dev/null 2>&1; then'
+require_text omarchy/zsh/personal.zsh 'eval "$(fnm env --use-on-cd --shell zsh)"'
+forbid_text omarchy/zsh/personal.zsh '^eval .*fnm env'
+forbid_text omarchy/zsh/personal.zsh 'atuin|sheldon|starship init|zoxide init|fzf --zsh'
 
-if grep -ERiq 'sheldon|atuin|starship init|zoxide init|fzf --zsh|fnm|mise' "$repo/omarchy/zsh/personal.zsh"; then
-  fail 'personal Omarchy overlay reinitializes an official/skipped shell tool'
-fi
-
-require_text .github/workflows/test-setup-ci.yml 'bash tests/omarchy-boundaries.sh'
-require_text .github/workflows/test-setup-ci.yml 'REQUIRE_ANSIBLE=1 bash tests/omarchy-integration.sh'
-require_text README.md '## Omarchy (opt-in)'
-require_text README.md 'ansible-playbook setup.yml -K --tags omarchy --check --diff'
-require_text README.md 'ansible-playbook setup.yml -K --tags omarchy'
-require_text README.md 'ansible-playbook setup.yml --tags omarchy_config'
-require_text README.md 'omarchy-setup-zsh'
-require_text README.md '### Omarchy rollback'
+# CI and docs exercise the split bootstrap/installer flow.
+require_text .github/workflows/test-setup-ci.yml 'bash tests/omarchy-installer.sh'
+require_text .github/workflows/test-setup-ci.yml 'install-omarchy.sh'
+require_text README.md './install-omarchy.sh --non-interactive --yes'
+for tool in git-lfs glow viu act pandoc-cli; do
+  require_text README.md "\`$tool\`"
+done
+require_text README.md 'omarchy-install.receipt'
 
 printf 'Omarchy boundary checks passed\n'

--- a/tests/omarchy-boundaries.sh
+++ b/tests/omarchy-boundaries.sh
@@ -36,8 +36,14 @@ fi
 
 # The installer's complete fixed catalog and public package route are explicit.
 require_text install-omarchy.sh 'catalog=(omarchy-zsh yazi shellcheck git-lfs glow viu act pandoc-cli fnm)'
+# Match source variable references literally, not this test's variables.
+# shellcheck disable=SC2016
 require_text install-omarchy.sh 'validate_csv "$components_csv" components zsh yazi'
+# Match the literal optional-tools validation call in the source.
+# shellcheck disable=SC2016
 require_text install-omarchy.sh 'validate_csv "$optional_csv" optional-tools shellcheck git-lfs glow viu act pandoc-cli'
+# Match the source array expansion without expanding it in this test.
+# shellcheck disable=SC2016
 require_text install-omarchy.sh 'run_recorded omarchy pkg add "${queued[@]}"'
 require_text install-omarchy.sh 'omarchy install dev-env node'
 require_text install-omarchy.sh 'omarchy-base.packages'
@@ -56,6 +62,8 @@ done
 forbid_text install-omarchy.sh 'arbitrary|passthrough|dev-env[[:space:]]+(python|go|rust|java)'
 
 # Bootstrap owns only the Omarchy Ansible prerequisite and never dispatches setup on that branch.
+# Match the bootstrap source condition, not the test environment's OS.
+# shellcheck disable=SC2016
 require_text bootstrap.sh '[[ $os_id == omarchy ]]'
 require_text bootstrap.sh 'omarchy pkg add ansible'
 require_text bootstrap.sh 'Prerequisites ready. Next: ./install-omarchy.sh'
@@ -104,6 +112,8 @@ personal_line=$(grep -nF 'source "$HOME/.config/dotfiles/zsh/personal.zsh"' "$zs
 # shellcheck disable=SC2016
 require_text omarchy/zsh/.zshrc 'export STARSHIP_CONFIG="$HOME/.config/dotfiles/starship.toml"'
 require_text omarchy/zsh/personal.zsh 'if (( $+commands[fnm] )) && ! mise where node >/dev/null 2>&1; then'
+# Match the Zsh source command substitution without executing fnm here.
+# shellcheck disable=SC2016
 require_text omarchy/zsh/personal.zsh 'eval "$(fnm env --use-on-cd --shell zsh)"'
 forbid_text omarchy/zsh/personal.zsh '^eval .*fnm env'
 forbid_text omarchy/zsh/personal.zsh 'atuin|sheldon|starship init|zoxide init|fzf --zsh'

--- a/tests/omarchy-installer.sh
+++ b/tests/omarchy-installer.sh
@@ -42,13 +42,23 @@ run_installer() {
 }
 
 run_bootstrap() {
+  # Only expose the utilities used by bootstrap and its fixtures. Falling back
+  # to /usr/bin or /bin would expose CI's Ansible in the missing-tool case.
+  local utility
+  for utility in bash dirname grep cp chmod; do
+    ln -s "$(command -v "$utility")" "$case_bin/$utility"
+  done
+  bootstrap_ansible_before=$(PATH="$case_bin" command -v ansible-playbook || true)
   set +e
-  PATH="$case_bin:/usr/bin:/bin" HOME="$case_home" OSTYPE=linux-gnu \
+  PATH="$case_bin" HOME="$case_home" OSTYPE=linux-gnu \
     DOTFILES_OS_RELEASE="$case_root/os-release" OMARCHY_PATH="$case_omarchy" \
     DOTFILES_MOCK_ROOT="$case_root" "$repo/bootstrap.sh" "$@" </dev/null \
     > "$case_root/output" 2>&1
   run_rc=$?
   set -e
+  bootstrap_ansible_after=$(PATH="$case_bin" command -v ansible-playbook || true)
+  printf 'Bootstrap Ansible resolution: before=%s after=%s\n' \
+    "${bootstrap_ansible_before:-absent}" "${bootstrap_ansible_after:-absent}"
 }
 
 assert_contains() { grep -Fq -- "$2" "$1" || fail "$1 missing: $2"; }
@@ -64,6 +74,8 @@ new_case bootstrap-missing
 rm "$case_bin/ansible-playbook"
 run_bootstrap
 [[ $run_rc -eq 0 ]] || fail 'bootstrap with missing Ansible failed'
+[[ -z $bootstrap_ansible_before ]] || fail 'missing-Ansible case exposed an executable'
+[[ $bootstrap_ansible_after == "$case_bin/ansible-playbook" ]] || fail 'bootstrap did not resolve installed fixture'
 [[ $(grep -c '^pkg add ansible$' "$case_root/calls") -eq 1 ]] || fail 'bootstrap did not add only Ansible once'
 grep -Fq 'Prerequisites ready. Next: ./install-omarchy.sh' "$case_root/output"
 [[ ! -s "$case_root/ansible-calls" ]] || fail 'Omarchy bootstrap ran setup.yml'
@@ -71,6 +83,8 @@ grep -Fq 'Prerequisites ready. Next: ./install-omarchy.sh' "$case_root/output"
 new_case bootstrap-present
 run_bootstrap
 [[ $run_rc -eq 0 ]] || fail 'bootstrap with present Ansible failed'
+[[ $bootstrap_ansible_before == "$case_bin/ansible-playbook" ]] || fail 'present-Ansible case did not resolve fixture'
+[[ $bootstrap_ansible_after == "$bootstrap_ansible_before" ]] || fail 'present-Ansible resolution changed'
 ! grep -q '^pkg add ' "$case_root/calls" || fail 'bootstrap reinstalled Ansible'
 [[ ! -s "$case_root/ansible-calls" ]] || fail 'Omarchy bootstrap ran setup.yml'
 

--- a/tests/omarchy-installer.sh
+++ b/tests/omarchy-installer.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+[[ -x "$repo/install-omarchy.sh" ]] || fail 'install-omarchy.sh is missing or not executable'
+
+new_case() {
+  case_root="$tmp/$1"
+  case_home="$case_root/home"
+  case_bin="$case_root/bin"
+  case_omarchy="$case_root/omarchy"
+  case_backup="$case_home/.dotfiles_backup/run"
+  mkdir -p "$case_home" "$case_bin" "$case_omarchy/default/hypr" "$case_omarchy/install"
+  cp "$repo/tests/fixtures/omarchy/bin/omarchy" "$case_bin/omarchy"
+  cp "$repo/tests/fixtures/omarchy/bin/mise" "$case_bin/mise"
+  cp "$repo/tests/fixtures/omarchy/bin/gum" "$case_bin/gum"
+  cp "$repo/tests/fixtures/omarchy/bin/ansible-galaxy" "$case_bin/ansible-galaxy"
+  cp "$repo/tests/fixtures/omarchy/bin/ansible-playbook.mock" "$case_bin/ansible-playbook"
+  cp "$repo/tests/fixtures/omarchy/bin/ansible-playbook.mock" "$case_bin/.ansible-playbook.mock"
+  cp "$repo/tests/fixtures/omarchy/bin/fnm.mock" "$case_bin/.fnm.mock"
+  chmod +x "$case_bin"/* "$case_bin"/.ansible-playbook.mock "$case_bin"/.fnm.mock
+  : > "$case_root/present"
+  : > "$case_root/calls"
+  : > "$case_root/gum-calls"
+  : > "$case_root/ansible-calls"
+  : > "$case_omarchy/install/omarchy-base.packages"
+  printf '%s\n' 'ID=omarchy' > "$case_root/os-release"
+  touch "$case_omarchy/default/hypr/bootstrap.lua"
+}
+
+run_installer() {
+  set +e
+  PATH="$case_bin:/usr/bin:/bin" HOME="$case_home" OSTYPE=linux-gnu \
+    DOTFILES_OS_RELEASE="$case_root/os-release" OMARCHY_PATH="$case_omarchy" \
+    DOTFILES_GUM="$case_bin/gum" DOTFILES_MOCK_ROOT="$case_root" \
+    "$repo/install-omarchy.sh" "$@" </dev/null > "$case_root/output" 2>&1
+  run_rc=$?
+  set -e
+}
+
+run_bootstrap() {
+  set +e
+  PATH="$case_bin:/usr/bin:/bin" HOME="$case_home" OSTYPE=linux-gnu \
+    DOTFILES_OS_RELEASE="$case_root/os-release" OMARCHY_PATH="$case_omarchy" \
+    DOTFILES_MOCK_ROOT="$case_root" "$repo/bootstrap.sh" "$@" </dev/null \
+    > "$case_root/output" 2>&1
+  run_rc=$?
+  set -e
+}
+
+assert_contains() { grep -Fq -- "$2" "$1" || fail "$1 missing: $2"; }
+
+assert_no_mutation() {
+  ! grep -Eq '^(pkg add|install dev-env|fnm (install|default) )' "$case_root/calls" ||
+    fail "$1 mutated"
+  [[ ! -e "$case_backup/omarchy-install.receipt" ]] || fail "$1 wrote a receipt"
+}
+
+# Bootstrap: missing Ansible uses exactly one public package call and never runs setup.yml.
+new_case bootstrap-missing
+rm "$case_bin/ansible-playbook"
+run_bootstrap
+[[ $run_rc -eq 0 ]] || fail 'bootstrap with missing Ansible failed'
+[[ $(grep -c '^pkg add ansible$' "$case_root/calls") -eq 1 ]] || fail 'bootstrap did not add only Ansible once'
+grep -Fq 'Prerequisites ready. Next: ./install-omarchy.sh' "$case_root/output"
+[[ ! -s "$case_root/ansible-calls" ]] || fail 'Omarchy bootstrap ran setup.yml'
+
+new_case bootstrap-present
+run_bootstrap
+[[ $run_rc -eq 0 ]] || fail 'bootstrap with present Ansible failed'
+! grep -q '^pkg add ' "$case_root/calls" || fail 'bootstrap reinstalled Ansible'
+[[ ! -s "$case_root/ansible-calls" ]] || fail 'Omarchy bootstrap ran setup.yml'
+
+new_case bootstrap-args
+run_bootstrap --tags omarchy
+[[ $run_rc -ne 0 ]] || fail 'Omarchy bootstrap accepted arguments'
+assert_no_mutation bootstrap-args
+
+new_case bootstrap-unknown
+printf '%s\n' 'ID=arch' > "$case_root/os-release"
+run_bootstrap
+[[ $run_rc -ne 0 ]] || fail 'unknown Linux bootstrap succeeded'
+assert_no_mutation bootstrap-unknown
+
+new_case bootstrap-marker-missing
+rm "$case_omarchy/default/hypr/bootstrap.lua"
+run_bootstrap
+[[ $run_rc -ne 0 ]] || fail 'Omarchy bootstrap accepted a missing marker'
+assert_no_mutation bootstrap-marker-missing
+
+# Non-interactive defaults: exact package batch, existing Mise Node preserved, config applied.
+new_case defaults
+printf '%s\n' '/mock/mise/installs/node/26.8.1' > "$case_root/mise-node"
+run_installer --non-interactive --yes --backup-dir "$case_backup"
+[[ $run_rc -eq 0 ]] || fail 'default non-interactive install failed'
+[[ $(grep -c '^pkg add ' "$case_root/calls") -eq 1 ]] || fail 'default plan did not use one package batch'
+grep -Fxq 'pkg add omarchy-zsh yazi shellcheck' "$case_root/calls"
+! grep -q '^install dev-env node$' "$case_root/calls" || fail 'active Mise Node was changed'
+[[ ! -s "$case_root/gum-calls" ]] || fail 'non-interactive run called Gum'
+grep -Fq -- '--tags omarchy_config' "$case_root/ansible-calls"
+grep -Fq 'omarchy_zsh_enabled=true' "$case_root/ansible-calls"
+grep -Fq 'omarchy_yazi_enabled=true' "$case_root/ansible-calls"
+receipt="$case_backup/omarchy-install.receipt"
+[[ -f $receipt ]] || fail 'default run did not write receipt'
+grep -Fq 'components: zsh,yazi' "$receipt"
+grep -Fq 'optional-tools: shellcheck' "$receipt"
+grep -Fq 'node-manager: mise' "$receipt"
+
+: > "$case_root/calls"
+run_installer --non-interactive --yes --backup-dir "$case_home/.dotfiles_backup/run2"
+[[ $run_rc -eq 0 ]] || fail 'second identical run failed'
+! grep -q '^pkg add ' "$case_root/calls" || fail 'second identical run added packages'
+
+# Stable optional order, base ownership, and present-package skips.
+new_case optional-order
+printf '%s\n' '/mock/mise/installs/node/26.8.1' > "$case_root/mise-node"
+run_installer --non-interactive --yes --components none \
+  --optional-tools pandoc-cli,act,viu,glow,git-lfs --config no \
+  --backup-dir "$case_backup"
+[[ $run_rc -eq 0 ]] || fail 'optional-tool run failed'
+grep -Fxq 'pkg add git-lfs glow viu act pandoc-cli' "$case_root/calls"
+[[ ! -s "$case_root/ansible-calls" ]] || fail 'config=no ran Ansible'
+
+new_case package-skips
+printf '%s\n' '/mock/mise/installs/node/26.8.1' > "$case_root/mise-node"
+printf '%s\n' 'yazi' > "$case_omarchy/install/omarchy-base.packages"
+printf '%s\n' yazi shellcheck > "$case_root/present"
+run_installer --non-interactive --yes --backup-dir "$case_backup"
+[[ $run_rc -eq 0 ]] || fail 'base/present skip run failed'
+grep -Fxq 'pkg add omarchy-zsh' "$case_root/calls"
+grep -Fq 'base-owned: yazi' "$case_root/output"
+grep -Fq 'already-present: shellcheck' "$case_root/output"
+
+# Dry-run and invalid input must stop before every mutation and receipt.
+new_case dry-run
+printf '%s\n' '/mock/mise/installs/node/26.8.1' > "$case_root/mise-node"
+run_installer --non-interactive --dry-run --backup-dir "$case_backup"
+[[ $run_rc -eq 0 ]] || fail 'dry-run failed'
+assert_no_mutation dry-run
+[[ ! -s "$case_root/ansible-calls" ]] || fail 'dry-run executed Ansible'
+grep -Fq -- '--check --diff' "$case_root/output"
+
+new_case fnm-dry-run
+run_installer --non-interactive --dry-run --components none --optional-tools none \
+  --node-manager fnm --fnm-node 22 --config no --backup-dir "$case_backup"
+[[ $run_rc -eq 0 ]] || fail 'fnm dry-run failed'
+assert_no_mutation fnm-dry-run
+assert_contains "$case_root/output" 'fnm install 22'
+assert_contains "$case_root/output" 'fnm default 22'
+
+new_case missing-yes
+printf '%s\n' '/mock/mise/installs/node/26.8.1' > "$case_root/mise-node"
+run_installer --non-interactive --backup-dir "$case_backup"
+[[ $run_rc -ne 0 ]] || fail 'mutating non-interactive run omitted --yes but succeeded'
+assert_no_mutation missing-yes
+
+new_case installer-ansible-missing
+rm "$case_bin/ansible-playbook"
+run_installer --non-interactive --yes --backup-dir "$case_backup"
+[[ $run_rc -ne 0 ]] || fail 'installer accepted missing Ansible prerequisite'
+assert_no_mutation installer-ansible-missing
+
+new_case installer-gum-missing
+rm "$case_bin/gum"
+run_installer --backup-dir "$case_backup"
+[[ $run_rc -ne 0 ]] || fail 'interactive installer accepted missing Gum'
+assert_no_mutation installer-gum-missing
+
+for invalid in '--unknown' '--components zsh,bad' '--optional-tools shellcheck,bad' \
+  '--node-manager bad' '--config maybe' '--backup-dir relative' 'positional'; do
+  new_case "invalid-${invalid//[^a-zA-Z0-9]/-}"
+  printf '%s\n' '/mock/mise/installs/node/26.8.1' > "$case_root/mise-node"
+  # Deliberately split each compact invalid test vector.
+  # shellcheck disable=SC2086
+  run_installer --non-interactive --yes $invalid
+  [[ $run_rc -ne 0 ]] || fail "invalid input succeeded: $invalid"
+  assert_no_mutation "invalid input $invalid"
+done
+
+# Mise/fnm exclusivity and actions.
+new_case mise-install
+run_installer --non-interactive --yes --config no --backup-dir "$case_backup"
+[[ $run_rc -eq 0 ]] || fail 'Mise-without-Node run failed'
+grep -Fxq 'install dev-env node' "$case_root/calls"
+
+new_case fnm-blocked-by-mise
+printf '%s\n' '/mock/mise/installs/node/26.8.1' > "$case_root/mise-node"
+run_installer --non-interactive --yes --components none --optional-tools none \
+  --node-manager fnm --fnm-node 22 --config no --backup-dir "$case_backup"
+[[ $run_rc -ne 0 ]] || fail 'fnm was allowed with active Mise Node'
+assert_no_mutation fnm-blocked-by-mise
+
+new_case mise-blocked-by-fnm
+cp "$repo/tests/fixtures/omarchy/bin/fnm.mock" "$case_bin/fnm"
+chmod +x "$case_bin/fnm"
+printf '%s\n' fnm > "$case_root/present"
+run_installer --non-interactive --yes --config no --backup-dir "$case_backup"
+[[ $run_rc -ne 0 ]] || fail 'Mise was allowed with fnm present'
+assert_no_mutation mise-blocked-by-fnm
+
+new_case fnm-valid
+run_installer --non-interactive --yes --components none --optional-tools none \
+  --node-manager fnm --fnm-node 22 --config no --backup-dir "$case_backup"
+[[ $run_rc -eq 0 ]] || fail 'valid fnm run failed'
+grep -Fxq 'pkg add fnm' "$case_root/calls"
+grep -Fxq 'fnm install 22' "$case_root/calls"
+grep -Fxq 'fnm default 22' "$case_root/calls"
+printf '%s\n' '22.9.1' > "$case_root/fnm-nodes"
+printf '%s\n' 'v22.9.1' > "$case_root/fnm-default"
+: > "$case_root/calls"
+run_installer --non-interactive --yes --components none --optional-tools none \
+  --node-manager fnm --fnm-node 22 --config no --backup-dir "$case_home/.dotfiles_backup/fnm2"
+[[ $run_rc -eq 0 ]] || fail 'second fnm run failed'
+! grep -Eq '^(pkg add|fnm (install|default) 22$)' "$case_root/calls" || fail 'second fnm run changed Node'
+
+# Interactive accepted defaults and cancellation at every prompt.
+new_case gum-defaults
+printf '%s\n' '/mock/mise/installs/node/26.8.1' > "$case_root/mise-node"
+printf '%s\n' 'Zsh overlay;Yazi' 'ShellCheck' 'Mise — recommended; preserve current Node' yes yes > "$case_root/gum-responses"
+run_installer --backup-dir "$case_backup"
+[[ $run_rc -eq 0 ]] || { printf '%s\n' '--- interactive output ---' >&2; command cat "$case_root/output" >&2; fail 'interactive defaults failed'; }
+grep -Fxq 'pkg add omarchy-zsh yazi shellcheck' "$case_root/calls"
+[[ $(wc -l < "$case_root/gum-calls") -eq 5 ]] || fail 'interactive defaults used the wrong prompt count'
+assert_contains "$case_root/output" "Target: $case_root/omarchy"
+assert_contains "$case_root/output" 'Active Node owner: Mise ('
+
+cancel_prefixes=(
+  '__CANCEL__'
+  'Zsh overlay;Yazi|__CANCEL__'
+  'Zsh overlay;Yazi|ShellCheck|__CANCEL__'
+  'Zsh overlay;Yazi|ShellCheck|Mise — recommended; preserve current Node|__CANCEL__'
+  'Zsh overlay;Yazi|ShellCheck|Mise — recommended; preserve current Node|yes|__CANCEL__'
+)
+index=0
+for responses in "${cancel_prefixes[@]}"; do
+  new_case "gum-cancel-$index"
+  printf '%s\n' '/mock/mise/installs/node/26.8.1' > "$case_root/mise-node"
+  tr '|' '\n' <<< "$responses" > "$case_root/gum-responses"
+  run_installer --backup-dir "$case_backup"
+  [[ $run_rc -ne 0 ]] || fail "Gum cancel $index succeeded"
+  assert_no_mutation "Gum cancel $index"
+  index=$((index + 1))
+done
+
+new_case gum-fnm-confirm-cancel
+printf '%s\n' 'Zsh overlay' 'ShellCheck' 'fnm — advanced; mutually exclusive' '__CANCEL__' > "$case_root/gum-responses"
+run_installer --backup-dir "$case_backup"
+[[ $run_rc -ne 0 ]] || fail 'Gum fnm confirmation cancel succeeded'
+assert_no_mutation gum-fnm-confirm-cancel
+
+# Ownership mismatches and invalid backup/duplicate options fail before mutation.
+new_case base-missing
+printf 'shellcheck\n' > "$case_root/omarchy/install/omarchy-base.packages"
+printf '%s\n' '/mock/mise/installs/node/26.8.1' > "$case_root/mise-node"
+run_installer --non-interactive --yes
+[[ $run_rc -ne 0 ]] || fail 'absent base-owned package was accepted'
+assert_no_mutation base-missing
+[[ ! -d $case_home/.dotfiles_backup ]] || fail 'ownership mismatch wrote a receipt'
+
+new_case invalid-options
+run_installer --non-interactive --yes --config yes --config no
+[[ $run_rc -ne 0 ]] || fail 'conflicting duplicate option was accepted'
+assert_no_mutation invalid-options
+run_installer --non-interactive --yes --backup-dir "$tmp/outside"
+[[ $run_rc -ne 0 ]] || fail 'backup directory outside HOME was accepted'
+assert_no_mutation invalid-backup
+
+# Package failure is receipted and stops Node/config execution.
+new_case package-failure
+touch "$case_root/fail-add"
+run_installer --non-interactive --yes --backup-dir "$case_home/.dotfiles_backup/failure"
+[[ $run_rc -ne 0 ]] || fail 'package failure was ignored'
+assert_contains "$case_home/.dotfiles_backup/failure/omarchy-install.receipt" 'status: 17'
+! grep -q '^install dev-env node$' "$case_root/calls" || fail 'Node ran after package failure'
+[[ ! -s $case_root/ansible-calls ]] || fail 'Ansible ran after package failure'
+
+printf 'Omarchy installer checks passed\n'

--- a/tests/omarchy-integration.sh
+++ b/tests/omarchy-integration.sh
@@ -13,61 +13,92 @@ fi
 
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
-home="$tmp/home"
 omarchy="$tmp/omarchy"
-omarchy_zsh="$tmp/omarchy-zsh"
 mock_bin="$tmp/bin"
-mkdir -p "$home" "$omarchy" "$omarchy_zsh" "$mock_bin"
+mkdir -p "$omarchy" "$mock_bin"
 cp -R "$repo/tests/fixtures/omarchy/default" "$omarchy/default"
-cp -R "$repo/tests/fixtures/omarchy-zsh/shell" "$omarchy_zsh/shell"
 cp "$repo/tests/fixtures/omarchy/bin/omarchy" "$mock_bin/omarchy"
 chmod +x "$mock_bin/omarchy"
-touch "$mock_bin/present" "$mock_bin/calls"
+: > "$tmp/present"
+: > "$tmp/calls"
 
 snapshot="$tmp/omarchy.before"
 find "$omarchy" -mindepth 1 -printf '%P %y %l\n' | LC_ALL=C sort > "$snapshot"
 
-run_omarchy() {
+run_config() {
   ansible-playbook "$repo/setup.yml" -i localhost, -c local \
     -e ansible_distribution=Omarchy \
     -e ansible_os_family=Archlinux \
     -e home="$home" \
     -e omarchy_path="$omarchy" \
     -e omarchy_command="$mock_bin/omarchy" \
-    -e omarchy_become=false \
+    -e "omarchy_zsh_enabled=$zsh_enabled" \
+    -e "omarchy_yazi_enabled=$yazi_enabled" \
     "$@"
 }
 
-run_omarchy --tags omarchy_config > "$tmp/config-run1.log"
-run_omarchy --tags omarchy_config | tee "$tmp/config-run2.log"
-grep -E 'changed=0 ' "$tmp/config-run2.log"
+assert_paths() {
+  local expected=$1 actual="$tmp/actual-paths"
+  find "$home" -mindepth 1 -printf '%P\n' | LC_ALL=C sort > "$actual"
+  diff -u "$expected" "$actual"
+}
 
-expected_paths="$tmp/expected-paths"
-actual_paths="$tmp/actual-paths"
-printf '%s\n' \
-  .config \
-  .config/dotfiles \
-  .config/dotfiles/starship.toml \
-  .config/dotfiles/zsh \
-  .config/dotfiles/zsh/personal.zsh \
-  .config/yazi \
-  .zprofile \
-  .zshrc | LC_ALL=C sort > "$expected_paths"
-find "$home" -mindepth 1 -printf '%P\n' | LC_ALL=C sort > "$actual_paths"
-diff -u "$expected_paths" "$actual_paths"
+# Both selected: all five managed targets, then a no-op second run.
+home="$tmp/both-home"
+zsh_enabled=true
+yazi_enabled=true
+mkdir "$home"
+printf '%s\n' .config .config/dotfiles .config/dotfiles/starship.toml \
+  .config/dotfiles/zsh .config/dotfiles/zsh/personal.zsh .config/yazi \
+  .zprofile .zshrc | LC_ALL=C sort > "$tmp/both-expected"
+run_config --tags omarchy_config > "$tmp/both-run1.log"
+run_config --tags omarchy_config | tee "$tmp/both-run2.log"
+grep -E 'changed=0 ' "$tmp/both-run2.log"
+assert_paths "$tmp/both-expected"
 cmp "$repo/omarchy/zsh/.zshrc" "$home/.zshrc"
 cmp "$repo/omarchy/zsh/.zprofile" "$home/.zprofile"
 [[ $(readlink "$home/.config/dotfiles/starship.toml") == "$repo/.config/starship.toml" ]]
 [[ $(readlink "$home/.config/dotfiles/zsh/personal.zsh") == "$repo/omarchy/zsh/personal.zsh" ]]
 [[ $(readlink "$home/.config/yazi") == "$repo/.config/yazi" ]]
 [[ ! -e "$home/.config/starship.toml" ]]
-grep -Fq 'OMARCHY_PATH:-/usr/share/omarchy' "$home/.zshrc"
-grep -Fq 'OMARCHY_ZSH_PATH:-/usr/share/omarchy-zsh' "$home/.zshrc"
-find "$omarchy" -mindepth 1 -printf '%P %y %l\n' | LC_ALL=C sort > "$tmp/omarchy.after"
-cmp "$snapshot" "$tmp/omarchy.after"
 
-clean_home=$home
+# Zsh-only, Yazi-only, and no-component config runs create exact subsets.
+home="$tmp/zsh-home"
+zsh_enabled=true
+yazi_enabled=false
+mkdir "$home"
+printf '%s\n' .config .config/dotfiles .config/dotfiles/starship.toml \
+  .config/dotfiles/zsh .config/dotfiles/zsh/personal.zsh .zprofile .zshrc |
+  LC_ALL=C sort > "$tmp/zsh-expected"
+run_config --tags omarchy_config > "$tmp/zsh-run1.log"
+run_config --tags omarchy_config > "$tmp/zsh-run2.log"
+grep -E 'changed=0 ' "$tmp/zsh-run2.log"
+assert_paths "$tmp/zsh-expected"
+
+home="$tmp/yazi-home"
+zsh_enabled=false
+yazi_enabled=true
+mkdir "$home"
+printf '%s\n' .config .config/yazi | LC_ALL=C sort > "$tmp/yazi-expected"
+run_config --tags omarchy_config > "$tmp/yazi-run1.log"
+run_config --tags omarchy_config > "$tmp/yazi-run2.log"
+grep -E 'changed=0 ' "$tmp/yazi-run2.log"
+assert_paths "$tmp/yazi-expected"
+
+home="$tmp/none-home"
+zsh_enabled=false
+yazi_enabled=false
+mkdir "$home"
+: > "$tmp/none-expected"
+run_config --tags omarchy_config > "$tmp/none-run1.log"
+run_config --tags omarchy_config > "$tmp/none-run2.log"
+grep -E 'changed=0 ' "$tmp/none-run2.log"
+assert_paths "$tmp/none-expected"
+
+# Existing targets are backed up under the explicitly supplied rollback root.
 home="$tmp/conflict-home"
+zsh_enabled=true
+yazi_enabled=true
 backup="$tmp/rollback"
 mkdir -p "$home/.config/dotfiles/zsh" "$home/.config/yazi"
 printf 'old-zshrc\n' > "$home/.zshrc"
@@ -75,23 +106,25 @@ printf 'old-zprofile\n' > "$home/.zprofile"
 printf 'old-personal\n' > "$home/.config/dotfiles/zsh/personal.zsh"
 printf 'old-starship\n' > "$home/.config/dotfiles/starship.toml"
 printf 'old-yazi\n' > "$home/.config/yazi/marker"
-run_omarchy -e backup_dir="$backup" --tags omarchy_config > "$tmp/backup-run1.log"
-run_omarchy -e backup_dir="$backup" --tags omarchy_config > "$tmp/backup-run2.log"
+run_config -e backup_dir="$backup" --tags omarchy_config > "$tmp/backup-run1.log"
+run_config -e backup_dir="$backup" --tags omarchy_config > "$tmp/backup-run2.log"
 grep -E 'changed=0 ' "$tmp/backup-run2.log"
 [[ $(<"$backup/.zshrc.bak") == old-zshrc ]]
 [[ $(<"$backup/.zprofile.bak") == old-zprofile ]]
 [[ $(<"$backup/.config_dotfiles_zsh_personal.zsh.bak") == old-personal ]]
 [[ $(<"$backup/.config_dotfiles_starship.toml.bak") == old-starship ]]
 [[ $(<"$backup/.config_yazi.bak/marker") == old-yazi ]]
-home=$clean_home
 
+# The Omarchy source fixture is input-only.
+find "$omarchy" -mindepth 1 -printf '%P %y %l\n' | LC_ALL=C sort > "$tmp/omarchy.after"
+cmp "$snapshot" "$tmp/omarchy.after"
+
+# Untagged Omarchy and an Omarchy tag on synthetic Debian both change nothing.
 legacy_home="$tmp/legacy-home"
 mkdir "$legacy_home"
 ansible-playbook "$repo/setup.yml" -i localhost, -c local \
-  -e ansible_distribution=Omarchy \
-  -e ansible_os_family=Archlinux \
-  -e home="$legacy_home" \
-  -e omarchy_path="$omarchy" \
+  -e ansible_distribution=Omarchy -e ansible_os_family=Archlinux \
+  -e home="$legacy_home" -e omarchy_path="$omarchy" \
   -e omarchy_command="$mock_bin/omarchy" > "$tmp/untagged.log"
 grep -E 'changed=0 ' "$tmp/untagged.log"
 [[ -z $(find "$legacy_home" -mindepth 1 -print -quit) ]]
@@ -99,25 +132,9 @@ grep -E 'changed=0 ' "$tmp/untagged.log"
 debian_home="$tmp/debian-home"
 mkdir "$debian_home"
 ansible-playbook "$repo/setup.yml" -i localhost, -c local \
-  -e ansible_distribution=Ubuntu \
-  -e ansible_os_family=Debian \
-  -e home="$debian_home" \
-  --tags omarchy_config > "$tmp/debian.log"
+  -e ansible_distribution=Ubuntu -e ansible_os_family=Debian \
+  -e home="$debian_home" --tags omarchy_config > "$tmp/debian.log"
 grep -E 'changed=0 ' "$tmp/debian.log"
 [[ -z $(find "$debian_home" -mindepth 1 -print -quit) ]]
-
-printf '%s\n' omarchy-zsh yazi > "$mock_bin/present"
-: > "$mock_bin/calls"
-run_omarchy --tags omarchy_packages > "$tmp/packages-present.log"
-grep -E 'changed=0 ' "$tmp/packages-present.log"
-[[ ! -s "$mock_bin/calls" ]]
-
-: > "$mock_bin/present"
-: > "$mock_bin/calls"
-run_omarchy --tags omarchy_packages > "$tmp/packages-missing.log"
-[[ $(wc -l < "$mock_bin/calls") -eq 1 ]]
-grep -Fxq 'add omarchy-zsh yazi' "$mock_bin/calls"
-run_omarchy --tags omarchy_packages > "$tmp/packages-run2.log"
-grep -E 'changed=0 ' "$tmp/packages-run2.log"
 
 printf 'Omarchy disposable-HOME integration checks passed\n'

--- a/tests/omarchy-integration.sh
+++ b/tests/omarchy-integration.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+if ! command -v ansible-playbook >/dev/null; then
+  if [[ ${REQUIRE_ANSIBLE:-0} == 1 ]]; then
+    printf 'ansible-playbook is required\n' >&2
+    exit 1
+  fi
+  printf 'SKIP: ansible-playbook is unavailable\n'
+  exit 0
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+home="$tmp/home"
+omarchy="$tmp/omarchy"
+omarchy_zsh="$tmp/omarchy-zsh"
+mock_bin="$tmp/bin"
+mkdir -p "$home" "$omarchy" "$omarchy_zsh" "$mock_bin"
+cp -R "$repo/tests/fixtures/omarchy/default" "$omarchy/default"
+cp -R "$repo/tests/fixtures/omarchy-zsh/shell" "$omarchy_zsh/shell"
+cp "$repo/tests/fixtures/omarchy/bin/omarchy" "$mock_bin/omarchy"
+chmod +x "$mock_bin/omarchy"
+touch "$mock_bin/present" "$mock_bin/calls"
+
+snapshot="$tmp/omarchy.before"
+find "$omarchy" -mindepth 1 -printf '%P %y %l\n' | LC_ALL=C sort > "$snapshot"
+
+run_omarchy() {
+  ansible-playbook "$repo/setup.yml" -i localhost, -c local \
+    -e ansible_distribution=Omarchy \
+    -e ansible_os_family=Archlinux \
+    -e home="$home" \
+    -e omarchy_path="$omarchy" \
+    -e omarchy_command="$mock_bin/omarchy" \
+    -e omarchy_become=false \
+    "$@"
+}
+
+run_omarchy --tags omarchy_config > "$tmp/config-run1.log"
+run_omarchy --tags omarchy_config | tee "$tmp/config-run2.log"
+grep -E 'changed=0 ' "$tmp/config-run2.log"
+
+expected_paths="$tmp/expected-paths"
+actual_paths="$tmp/actual-paths"
+printf '%s\n' \
+  .config \
+  .config/dotfiles \
+  .config/dotfiles/starship.toml \
+  .config/dotfiles/zsh \
+  .config/dotfiles/zsh/personal.zsh \
+  .config/yazi \
+  .zprofile \
+  .zshrc | LC_ALL=C sort > "$expected_paths"
+find "$home" -mindepth 1 -printf '%P\n' | LC_ALL=C sort > "$actual_paths"
+diff -u "$expected_paths" "$actual_paths"
+cmp "$repo/omarchy/zsh/.zshrc" "$home/.zshrc"
+cmp "$repo/omarchy/zsh/.zprofile" "$home/.zprofile"
+[[ $(readlink "$home/.config/dotfiles/starship.toml") == "$repo/.config/starship.toml" ]]
+[[ $(readlink "$home/.config/dotfiles/zsh/personal.zsh") == "$repo/omarchy/zsh/personal.zsh" ]]
+[[ $(readlink "$home/.config/yazi") == "$repo/.config/yazi" ]]
+[[ ! -e "$home/.config/starship.toml" ]]
+grep -Fq 'OMARCHY_PATH:-/usr/share/omarchy' "$home/.zshrc"
+grep -Fq 'OMARCHY_ZSH_PATH:-/usr/share/omarchy-zsh' "$home/.zshrc"
+find "$omarchy" -mindepth 1 -printf '%P %y %l\n' | LC_ALL=C sort > "$tmp/omarchy.after"
+cmp "$snapshot" "$tmp/omarchy.after"
+
+clean_home=$home
+home="$tmp/conflict-home"
+backup="$tmp/rollback"
+mkdir -p "$home/.config/dotfiles/zsh" "$home/.config/yazi"
+printf 'old-zshrc\n' > "$home/.zshrc"
+printf 'old-zprofile\n' > "$home/.zprofile"
+printf 'old-personal\n' > "$home/.config/dotfiles/zsh/personal.zsh"
+printf 'old-starship\n' > "$home/.config/dotfiles/starship.toml"
+printf 'old-yazi\n' > "$home/.config/yazi/marker"
+run_omarchy -e backup_dir="$backup" --tags omarchy_config > "$tmp/backup-run1.log"
+run_omarchy -e backup_dir="$backup" --tags omarchy_config > "$tmp/backup-run2.log"
+grep -E 'changed=0 ' "$tmp/backup-run2.log"
+[[ $(<"$backup/.zshrc.bak") == old-zshrc ]]
+[[ $(<"$backup/.zprofile.bak") == old-zprofile ]]
+[[ $(<"$backup/.config_dotfiles_zsh_personal.zsh.bak") == old-personal ]]
+[[ $(<"$backup/.config_dotfiles_starship.toml.bak") == old-starship ]]
+[[ $(<"$backup/.config_yazi.bak/marker") == old-yazi ]]
+home=$clean_home
+
+legacy_home="$tmp/legacy-home"
+mkdir "$legacy_home"
+ansible-playbook "$repo/setup.yml" -i localhost, -c local \
+  -e ansible_distribution=Omarchy \
+  -e ansible_os_family=Archlinux \
+  -e home="$legacy_home" \
+  -e omarchy_path="$omarchy" \
+  -e omarchy_command="$mock_bin/omarchy" > "$tmp/untagged.log"
+grep -E 'changed=0 ' "$tmp/untagged.log"
+[[ -z $(find "$legacy_home" -mindepth 1 -print -quit) ]]
+
+debian_home="$tmp/debian-home"
+mkdir "$debian_home"
+ansible-playbook "$repo/setup.yml" -i localhost, -c local \
+  -e ansible_distribution=Ubuntu \
+  -e ansible_os_family=Debian \
+  -e home="$debian_home" \
+  --tags omarchy_config > "$tmp/debian.log"
+grep -E 'changed=0 ' "$tmp/debian.log"
+[[ -z $(find "$debian_home" -mindepth 1 -print -quit) ]]
+
+printf '%s\n' omarchy-zsh yazi > "$mock_bin/present"
+: > "$mock_bin/calls"
+run_omarchy --tags omarchy_packages > "$tmp/packages-present.log"
+grep -E 'changed=0 ' "$tmp/packages-present.log"
+[[ ! -s "$mock_bin/calls" ]]
+
+: > "$mock_bin/present"
+: > "$mock_bin/calls"
+run_omarchy --tags omarchy_packages > "$tmp/packages-missing.log"
+[[ $(wc -l < "$mock_bin/calls") -eq 1 ]]
+grep -Fxq 'add omarchy-zsh yazi' "$mock_bin/calls"
+run_omarchy --tags omarchy_packages > "$tmp/packages-run2.log"
+grep -E 'changed=0 ' "$tmp/packages-run2.log"
+
+printf 'Omarchy disposable-HOME integration checks passed\n'

--- a/vars/Darwin.yml
+++ b/vars/Darwin.yml
@@ -1,5 +1,5 @@
 ---
-# macOS values, loaded by setup.yml via vars_files on ansible_os_family.
+# macOS values, loaded by setup.yml from ansible_os_family.
 brew_prefix: "{{ '/opt/homebrew' if ansible_architecture == 'arm64' else '/usr/local' }}"
 fonts_dir: "{{ ansible_env.HOME }}/Library/Fonts"
 brew_formulae: "{{ formulae | dict2items | map(attribute='value') | flatten }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,5 @@
 ---
-# Debian/Ubuntu/Mint values, loaded by setup.yml via vars_files on ansible_os_family.
+# Debian/Ubuntu/Mint values, loaded by setup.yml from ansible_os_family.
 brew_prefix: /home/linuxbrew/.linuxbrew
 fonts_dir: "{{ ansible_env.HOME }}/.local/share/fonts"
 zsh_path: /usr/bin/zsh

--- a/vars/Omarchy.yml
+++ b/vars/Omarchy.yml
@@ -1,17 +1,14 @@
 ---
 omarchy_path: /usr/share/omarchy
-omarchy_packages:
-  - omarchy-zsh
-  - yazi
 omarchy_zsh_enabled: true
 omarchy_yazi_enabled: true
 omarchy_links:
   - src: omarchy/zsh/personal.zsh
     dest: .config/dotfiles/zsh/personal.zsh
-    enabled: "{{ omarchy_zsh_enabled }}"
+    enabled: "{{ omarchy_zsh_enabled | bool }}"
   - src: .config/starship.toml
     dest: .config/dotfiles/starship.toml
-    enabled: "{{ omarchy_zsh_enabled }}"
+    enabled: "{{ omarchy_zsh_enabled | bool }}"
   - src: .config/yazi
     dest: .config/yazi
-    enabled: "{{ omarchy_yazi_enabled }}"
+    enabled: "{{ omarchy_yazi_enabled | bool }}"

--- a/vars/Omarchy.yml
+++ b/vars/Omarchy.yml
@@ -1,0 +1,17 @@
+---
+omarchy_path: /usr/share/omarchy
+omarchy_packages:
+  - omarchy-zsh
+  - yazi
+omarchy_zsh_enabled: true
+omarchy_yazi_enabled: true
+omarchy_links:
+  - src: omarchy/zsh/personal.zsh
+    dest: .config/dotfiles/zsh/personal.zsh
+    enabled: "{{ omarchy_zsh_enabled }}"
+  - src: .config/starship.toml
+    dest: .config/dotfiles/starship.toml
+    enabled: "{{ omarchy_zsh_enabled }}"
+  - src: .config/yazi
+    dest: .config/yazi
+    enabled: "{{ omarchy_yazi_enabled }}"


### PR DESCRIPTION
## Summary

This revision changes the Omarchy support into a two-step, guided workflow:

1. `./bootstrap.sh` detects `ID=omarchy`, validates the public Omarchy CLI/marker, ensures only Ansible plus the existing `community.general` requirement, prints the next command, and exits without running `setup.yml`.
2. `./install-omarchy.sh` owns interactive selection, package/Node planning, config dispatch, confirmation, and the install receipt.

The Gum wizard defaults to the Zsh overlay, Yazi, ShellCheck, the existing Mise-managed Node, and config apply. Its deterministic mode accepts only the documented flags and requires `--yes` for mutation. Dry-run performs read-only detection and prints the exact package, Node, Ansible-check, backup, rollback, and receipt plan without creating a receipt.

## Package and Node policy

The fixed package catalog is:

- core: `omarchy-zsh`, `yazi`
- optional trusted-repository tools: `shellcheck`, `git-lfs`, `glow`, `viu`, `act`, `pandoc-cli`
- advanced Node alternative: `fnm`

Selected base-manifest packages and already-present packages are reconciled rather than reinstalled. Missing selected packages are sent in stable catalog order to at most one `omarchy pkg add` call.

Mise remains the default Node owner. If `mise where node` resolves, the installer records and preserves that exact path and performs no Node command. If it does not resolve, the default plan uses only `omarchy install dev-env node`. `fnm` is visible but advanced and strictly mutually exclusive: it cannot be selected while Mise owns Node, and the Mise path refuses an existing fnm package/command. A valid fnm plan requires an explicit version in non-interactive mode, installs only an absent version, and changes the fnm default only when needed. The Zsh overlay initializes fnm only when fnm exists and Mise does not own Node.

## Configuration and ownership

Ansible is config-only for Omarchy under `[omarchy_config, never]`. The installer passes explicit Zsh/Yazi booleans and a backup directory under `~/.dotfiles_backup`. Managed paths remain limited to:

- `~/.zshrc`
- `~/.zprofile`
- `~/.config/dotfiles/zsh/personal.zsh`
- `~/.config/dotfiles/starship.toml`
- `~/.config/yazi`

Official Omarchy environment/Zsh loaders still run before the personal overlay. The repository Starship file is selected only through `STARSHIP_CONFIG`; Omarchy's canonical Starship path is not replaced. Yazi remains the only overlapping application config.

A confirmed run writes `omarchy-install.receipt` before package, Node, or config execution. It records repository HEAD/date, selections, ownership/presence decisions, resolved Node state/action, Ansible booleans/tag, exact commands, and exit statuses. Package failure stops all downstream Node/config work.

## Preserved and deferred scope

This does not port the Mint/macOS/Debian setup to Omarchy. It does not add or manage AWS, Ollama, terminal switching, AUR/API/load tools, arbitrary packages, other languages, Atuin, Sheldon, Ghostty, package removal, Hyprland/tiling/bindings, shell/bar/Quickshell, themes, Foot, Neovim/LazyVim, tmux, fonts, the Bash loader, automatic Zsh activation, or anything under `/usr/share/omarchy`.

Legacy macOS/Debian bootstrap and playbook behavior remains unchanged.

## Latest bounded repair evidence

Head: `f06f7c2d62095fd8a94a5373030e7d5e64d21fb4`. Only `tests/omarchy-installer.sh` changed: bootstrap fixtures now expose an allowlisted utility PATH, preserve actual command-availability semantics and exact one-install/present-tool assertions, and record before/after Ansible resolution. No product or CI changes.

Local Bash syntax, boundary, full mocked installer suite, and diff whitespace checks passed. The suite also passed with outer PATH restricted to `/usr/bin:/bin` (Ansible absent); the normal outer PATH resolved Ansible from `/home/yordank/.local/bin/ansible-playbook`. Strict ShellCheck remained unavailable locally (exit 127). Required integration under a disposable HOME was blocked by missing `community.general.homebrew` (exit 4), not a pass. No host packages were installed.

[Run 33952631868](https://github.com/yordan-kanchelov/dotfiles/actions/runs/33952631868) reached terminal failure. Lint, Mint release resolution, macOS setup, and Ubuntu setup passed. The [Omarchy job](https://github.com/yordan-kanchelov/dotfiles/actions/runs/33952631868/job/101270138807) passed unchanged strict ShellCheck and all static/syntax checks. Required disposable-HOME integration printed `Omarchy disposable-HOME integration checks passed`. Bootstrap missing/present checks passed with CI-installed Ansible: resolution was absent before installation and the fixture afterward; the present fixture remained unchanged. A later mocked-installer case failed with `FAIL: installer accepted missing Ansible prerequisite` (exit 1). The full CI installer suite therefore does NOT pass. Further repair stopped at the authorized bounded-round limit pending Manager/user decision. Architect, independent Code Reviewer, and QA gates remain pending. No merge.

## Historical test evidence (superseded by latest results above)

Local repository-only checks:

- `bash tests/omarchy-boundaries.sh` — PASS (`Omarchy boundary checks passed`)
- `bash tests/omarchy-installer.sh` — PASS (`Omarchy installer checks passed`)
- `bash -n bootstrap.sh install-omarchy.sh tests/omarchy-boundaries.sh tests/omarchy-integration.sh tests/omarchy-installer.sh tests/fixtures/omarchy/bin/omarchy tests/fixtures/omarchy/bin/gum tests/fixtures/omarchy/bin/mise tests/fixtures/omarchy/bin/ansible-galaxy tests/fixtures/omarchy/bin/fnm.mock tests/fixtures/omarchy/bin/ansible-playbook.mock` — PASS
- `git diff --check` — PASS
- `git fsck --full --no-progress` — PASS
- `bash tests/omarchy-integration.sh` — exits 0 with `SKIP: ansible-playbook is unavailable`

Local `shellcheck`, `ansible-playbook`, `ansible-lint`, and `zsh` executables were unavailable; nothing was installed.

Repair head: `6065dfc230ee9107a6b02ba267e85e4bd1897f2e`. Only receipt redirect grouping and five explained command-scoped literal-pattern suppressions changed; assertions and CI severity remain intact.

Local repair checks: Bash syntax for bootstrap/installer/three test scripts, boundary checks, mocked installer checks, and `git diff --check` passed. Required local integration reported `ansible-playbook is required`; direct ShellCheck was unavailable (exit 127), not a pass. Docker access and disposable validator extraction were blocked; no host tools were installed.

Fresh [run 33949258011](https://github.com/yordan-kanchelov/dotfiles/actions/runs/33949258011) is terminal. Lint, Mint release resolution, macOS setup, and Ubuntu setup passed. In the [Omarchy job](https://github.com/yordan-kanchelov/dotfiles/actions/runs/33949258011/job/101260819011), the unchanged strict workflow ShellCheck invocation and all static/syntax checks passed. `REQUIRE_ANSIBLE=1 bash tests/omarchy-integration.sh` ran and printed `Omarchy disposable-HOME integration checks passed`. The subsequent `bash tests/omarchy-installer.sh` failed with `FAIL: bootstrap did not add only Ansible once` (exit 1). Thus the job and overall workflow remain failed. Design-fit, independent Code Reviewer, and QA gates remain pending. No merge; this PR does not claim a green final gate.

## Limitations

All apply-like coverage uses fixture Omarchy paths, mocked commands, and disposable HOME directories. No real-host bootstrap/installer/playbook, package/runtime/Mise/fnm/chsh/compositor command, reboot/login check, Hyprland key dispatch, graphical behavior, or future-Omarchy-update compatibility was exercised. Package and Node rollback is intentionally not automated; config rollback is limited to the five documented managed paths and receipt backup directory.


